### PR TITLE
ID class refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 *.war
 *.ear
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -51,5 +50,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
 </project>

--- a/src/main/java/itc4j/ID.java
+++ b/src/main/java/itc4j/ID.java
@@ -64,21 +64,17 @@ public final class ID implements Serializable {
         return isLeaf() && value == 1;
     }
 
-    static ID normalize(ID id) {
-        assert id != null;
-        id.normalizeChildren();
-        if (id.isLeaf()) {
-            return id;
+    ID normalize() {
+        if (!isLeaf()) {
+            normalizeChildren();
+            if (left.isZero() && right.isZero()) {
+                return newID_0();
+            }
+            else if (left.isOne() && right.isOne()) {
+                return newID_1();
+            }
         }
-        else if (id.getLeft().isZero() && id.getRight().isZero()) {
-            return newID_0();
-        }
-        else if (id.getLeft().isOne() && id.getRight().isOne()) {
-            return newID_1();
-        }
-        else {
-            return id;
-        }
+        return this;
     }
 
     private void normalizeChildren() {
@@ -91,11 +87,11 @@ public final class ID implements Serializable {
     }
 
     private void normalizeRight() {
-        right = normalize(right);
+        right = right.normalize();
     }
 
     private void normalizeLeft() {
-        left = normalize(left);
+        left = left.normalize();
     }
 
     ID[] split() {
@@ -164,7 +160,8 @@ public final class ID implements Serializable {
         else {
             ID leftSum = left.sum(other.getLeft());
             ID rightSum = right.sum(other.getRight());
-            return normalize(new ID(leftSum, rightSum));
+            ID sum = new ID(leftSum, rightSum);
+            return sum.normalize();
         }
     }
 

--- a/src/main/java/itc4j/ID.java
+++ b/src/main/java/itc4j/ID.java
@@ -1,223 +1,38 @@
 package itc4j;
 
-import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Sina Bagherzadeh
  */
-public final class ID implements Serializable {
-
-    public static final ID ID_0 = newID_0();
-    public static final ID ID_1 = newID_1();
-
-    public static ID newID_0() {
-        return new ID(0);
-    }
-
-    public static ID newID_1() {
-        return new ID(1);
-    }
-
-    private ID left;
-    private ID right;
-    private final int value;
-
-    private ID(int value) {
-        this.value = value;
-    }
-
-    ID(ID left, ID right) {
-        this.left = left;
-        this.right = right;
-        this.value = -1;
-    }
-
-    private int getValue() {
-        return value;
-    }
-
-    public ID getLeft() {
-        return left;
-    }
-
-    public ID getRight() {
-        return right;
-    }
+public abstract class ID implements Cloneable {
     
-    private boolean hasLeft() {
-        return left != null;
-    }
+    abstract ID getLeft();
     
-    private boolean hasRight() {
-        return right != null;
-    }
+    abstract ID getRight();
     
-    boolean isLeaf() {
-        return !hasLeft() && !hasRight();
-    }
+    abstract boolean isLeaf();
     
-    boolean isZero() {
-        return isLeaf() && value == 0;
-    }
+    abstract boolean isZero();
     
-    boolean isOne() {
-        return isLeaf() && value == 1;
-    }
+    abstract boolean isOne();
 
-    ID normalize() {
-        if (!isLeaf()) {
-            normalizeChildren();
-            if (left.isZero() && right.isZero()) {
-                return newID_0();
-            }
-            else if (left.isOne() && right.isOne()) {
-                return newID_1();
-            }
-        }
-        return this;
-    }
+    abstract ID normalize();
 
-    private void normalizeChildren() {
-        if (hasRight()) {
-            normalizeRight();
-        }
-        if (hasLeft()) {
-            normalizeLeft();
-        }
-    }
+    abstract ID[] split();
 
-    private void normalizeRight() {
-        right = right.normalize();
-    }
-
-    private void normalizeLeft() {
-        left = left.normalize();
-    }
-
-    ID[] split() {
-        if (isLeaf()) {
-            return splitLeaf();
-        }
-        else {
-            return splitNode();
-        }
-    }
-
-    private ID[] splitLeaf() {
-        if (isZero()) {
-            return new ID[] { newID_0(), newID_0() };
-        }
-        else { // if (isOne()) {
-            return new ID[] {
-                new ID(newID_1(), newID_0()),
-                new ID(newID_0(), newID_1())
-            };
-        }
-    }
-
-    private ID[] splitNode() {
-        if (hasLeft() && left.isZero()) {
-            return splitWithLeftZero();
-        }
-        else if (hasRight() && getRight().isZero()) {
-            return splitWithRightZero();
-        }
-        else {
-            return new ID[] {
-                new ID(left.clone(), newID_0()),
-                new ID(newID_0(), right.clone())
-            };
-        }
-    }
-
-    private ID[] splitWithLeftZero() {
-        ID[] rightSplit = right.split();
-        return new ID[] {
-            new ID(newID_0(), rightSplit[0]),
-                new ID(newID_0(), rightSplit[1])
-        };
-    }
-
-    private ID[] splitWithRightZero() {
-        ID[] leftSplit = left.split();
-        return new ID[] {
-            new ID(leftSplit[0], newID_0()),
-                new ID(leftSplit[1], newID_0())
-        };
-    }
-
-    ID sum(ID other) {
-        assert other != null;
-        if(this.isOne() && other.isOne()) {
-            throw new IllegalArgumentException("Can't sum 1 with 1.");
-        }
-        if (this.isZero()) {
-            return other;
-        }
-        else if (other.isZero()) {
-            return this;
-        }
-        else {
-            ID leftSum = left.sum(other.getLeft());
-            ID rightSum = right.sum(other.getRight());
-            ID sum = new ID(leftSum, rightSum);
-            return sum.normalize();
-        }
-    }
+    abstract ID sum(ID other);
 
     @Override
-    public boolean equals(Object object) {
-        if (!(object instanceof ID)) {
-            return false;
+    protected ID clone() {
+        try {
+            return (ID)super.clone();
         }
-        else {
-            return equalsID((ID)object);
-        }
-    }
-
-    private boolean equalsID(ID other) {
-        if (this.isLeaf() && other.isLeaf()) {
-            return value == other.getValue();
-        }
-        else if(!this.isLeaf() && !this.isLeaf()) {
-            return left.equalsID(other.getLeft()) && right.equalsID(other.getRight());
-        }
-        else {
-            return false;
+        catch(CloneNotSupportedException ex) {
+            Logger.getLogger(ID.class.getName()).log(Level.SEVERE, null, ex);
+            return null;
         }
     }
-
-    @Override
-    public String toString() {
-        if (isLeaf()) {
-            return String.valueOf(getValue());
-        }
-        else {
-            return "(" + getLeft() + ", " + getRight() + ")";
-        }
-    }
-
-    @Override
-    @SuppressWarnings({"CloneDoesntCallSuperClone"})
-    public ID clone() {
-        if (isLeaf()) {
-            return new ID(getValue());
-        }
-        else {
-            return cloneNode();
-        }
-    }
-
-    private ID cloneNode() {
-        ID leftClone = null;
-        ID rightClone = null;
-        if (hasLeft()) {
-            leftClone = left.clone();
-        }
-        if (hasRight()) {
-            rightClone = right.clone();
-        }
-        return new ID(leftClone, rightClone);
-    }
-
+    
 }

--- a/src/main/java/itc4j/ID.java
+++ b/src/main/java/itc4j/ID.java
@@ -7,12 +7,20 @@ import java.io.Serializable;
  */
 public final class ID implements Serializable {
 
-    public static final ID ID_0 = new ID(0);
-    public static final ID ID_1 = new ID(1);
+    public static final ID ID_0 = newID_0();
+    public static final ID ID_1 = newID_1();
+
+    public static ID newID_0() {
+        return new ID(0);
+    }
+
+    public static ID newID_1() {
+        return new ID(1);
+    }
 
     private ID left;
     private ID right;
-    private int value = -1;
+    private final int value;
 
     private ID(int value) {
         this.value = value;
@@ -21,14 +29,11 @@ public final class ID implements Serializable {
     ID(ID left, ID right) {
         this.left = left;
         this.right = right;
+        this.value = -1;
     }
 
-    public static ID newID_1() {
-        return new ID(1);
-    }
-
-    public static ID newID_0() {
-        return new ID(0);
+    private int getValue() {
+        return value;
     }
 
     public ID getLeft() {
@@ -38,90 +43,184 @@ public final class ID implements Serializable {
     public ID getRight() {
         return right;
     }
+    
+    private boolean hasLeft() {
+        return left != null;
+    }
+    
+    private boolean hasRight() {
+        return right != null;
+    }
+    
+    boolean isLeaf() {
+        return !hasLeft() && !hasRight();
+    }
+    
+    boolean isZero() {
+        return isLeaf() && value == 0;
+    }
+    
+    boolean isOne() {
+        return isLeaf() && value == 1;
+    }
 
-    @SuppressWarnings("ConstantConditions")
-    protected static ID norm(ID id) {
+    static ID normalize(ID id) {
         assert id != null;
-        if (id.right != null)
-            id.right = norm(id.right);
-        if (id.left != null)
-            id.left = norm(id.left);
-        if (id.left == null && id.right == null) {
-            if (id.value == 0)
-                return newID_0();
-            if (id.value == 1)
-                return newID_1();
+        id.normalizeChildren();
+        if (id.isLeaf()) {
+            return id;
         }
-        if (id.left.equals(ID_0) && id.right.equals(ID_0))
+        else if (id.getLeft().isZero() && id.getRight().isZero()) {
             return newID_0();
-        if (id.left.equals(ID_1) && id.right.equals(ID_1))
+        }
+        else if (id.getLeft().isOne() && id.getRight().isOne()) {
             return newID_1();
-        return id;
-    }
-
-    protected static ID[] split(ID id) {
-        assert id != null;
-        if (id.equals(ID_0))
-            return new ID[]{newID_0(), newID_0()};
-        if (id.equals(ID_1))
-            return new ID[]{new ID(newID_1(), newID_0()), new ID(newID_0(), newID_1())};
-        if (id.left != null && id.left.equals(ID_0)) {
-            ID[] rightSplit = split(id.right);
-            return new ID[]{new ID(newID_0(), rightSplit[0]), new ID(newID_0(), rightSplit[1])};
         }
-        if (id.right != null && id.right.equals(ID_0)) {
-            ID[] leftSplit = split(id.left);
-            return new ID[]{new ID(leftSplit[0], newID_0()), new ID(leftSplit[1], newID_0())};
+        else {
+            return id;
         }
-        return new ID[]{new ID(id.left, newID_0()), new ID(newID_0(), id.right)};
     }
 
-    protected static ID sum(ID id1, ID id2) {
-        assert id1 != null && id2 != null;
-        if (id1.equals(ID_0))
-            return id2;
-        if (id2.equals(ID_0))
-            return id1;
-        return norm(new ID(sum(id1.left, id2.left), sum(id1.right, id2.right)));
+    private void normalizeChildren() {
+        if (hasRight()) {
+            normalizeRight();
+        }
+        if (hasLeft()) {
+            normalizeLeft();
+        }
     }
 
-    @SuppressWarnings({"ConstantConditions", "SimplifiableIfStatement"})
-    public boolean equals(Object o) {
-        if (o == null)
-            return false;
-        if (!(o instanceof ID))
-            return false;
-        ID id = (ID) o;
-        if ((left == null && id.left != null) || (left != null && id.left == null))
-            return false;
-        if ((right != null && id.right == null) || (right == null && id.right != null))
-            return false;
-        if (left == null && id.left == null && right == null && id.right == null)
-            return value == id.value;
-        if (left != null && right != null && id.left != null && id.right != null)
-            return left.equals(id.left) && right.equals(id.right);
-        return false;
+    private void normalizeRight() {
+        right = normalize(right);
     }
 
-    @SuppressWarnings({"ConstantConditions"})
+    private void normalizeLeft() {
+        left = normalize(left);
+    }
+
+    ID[] split() {
+        if (isLeaf()) {
+            return splitLeaf();
+        }
+        else {
+            return splitNode();
+        }
+    }
+
+    private ID[] splitLeaf() {
+        if (isZero()) {
+            return new ID[] { newID_0(), newID_0() };
+        }
+        else { // if (isOne()) {
+            return new ID[] {
+                new ID(newID_1(), newID_0()),
+                new ID(newID_0(), newID_1())
+            };
+        }
+    }
+
+    private ID[] splitNode() {
+        if (hasLeft() && left.isZero()) {
+            return splitWithLeftZero();
+        }
+        else if (hasRight() && getRight().isZero()) {
+            return splitWithRightZero();
+        }
+        else {
+            return new ID[] {
+                new ID(left.clone(), newID_0()),
+                new ID(newID_0(), right.clone())
+            };
+        }
+    }
+
+    private ID[] splitWithLeftZero() {
+        ID[] rightSplit = right.split();
+        return new ID[] {
+            new ID(newID_0(), rightSplit[0]),
+                new ID(newID_0(), rightSplit[1])
+        };
+    }
+
+    private ID[] splitWithRightZero() {
+        ID[] leftSplit = left.split();
+        return new ID[] {
+            new ID(leftSplit[0], newID_0()),
+                new ID(leftSplit[1], newID_0())
+        };
+    }
+
+    ID sum(ID other) {
+        assert other != null;
+        if(this.isOne() && other.isOne()) {
+            throw new IllegalArgumentException("Can't sum 1 with 1.");
+        }
+        if (this.isZero()) {
+            return other;
+        }
+        else if (other.isZero()) {
+            return this;
+        }
+        else {
+            ID leftSum = left.sum(other.getLeft());
+            ID rightSum = right.sum(other.getRight());
+            return normalize(new ID(leftSum, rightSum));
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof ID)) {
+            return false;
+        }
+        else {
+            return equalsID((ID)object);
+        }
+    }
+
+    private boolean equalsID(ID other) {
+        if (this.isLeaf() && other.isLeaf()) {
+            return value == other.getValue();
+        }
+        else if(!this.isLeaf() && !this.isLeaf()) {
+            return left.equalsID(other.getLeft()) && right.equalsID(other.getRight());
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
-        if (left == null && right == null)
-            return String.valueOf(value);
-        if (left.equals(ID_0))
-            return "(0, " + right + ")";
-        if (right.equals(ID_0))
-            return "(" + left + ", 0)";
-        return "(" + left + ", " + right + ")";
+        if (isLeaf()) {
+            return String.valueOf(getValue());
+        }
+        else {
+            return "(" + getLeft() + ", " + getRight() + ")";
+        }
     }
 
+    @Override
     @SuppressWarnings({"CloneDoesntCallSuperClone"})
     public ID clone() {
-        ID clone = new ID(value);
-        if (right != null)
-            clone.right = right.clone();
-        if (left != null)
-            clone.left = left.clone();
-        return clone;
+        if (isLeaf()) {
+            return new ID(getValue());
+        }
+        else {
+            return cloneNode();
+        }
+    }
+
+    private ID cloneNode() {
+        ID leftClone = null;
+        ID rightClone = null;
+        if (hasLeft()) {
+            leftClone = left.clone();
+        }
+        if (hasRight()) {
+            rightClone = right.clone();
+        }
+        return new ID(leftClone, rightClone);
     }
 
 }

--- a/src/main/java/itc4j/IDs.java
+++ b/src/main/java/itc4j/IDs.java
@@ -1,0 +1,26 @@
+
+package itc4j;
+
+/**
+ * IDs
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 28/mai/2015
+ */
+final class IDs {
+    
+    public static ID zero() {
+        return new LeafID(0);
+    }
+    
+    public static ID one() {
+        return new LeafID(1);
+    }
+    
+    public static ID with(ID id1, ID id2) {
+        return new NonLeafID(id1, id2);
+    }
+
+    private IDs() { }
+    
+}

--- a/src/main/java/itc4j/LeafID.java
+++ b/src/main/java/itc4j/LeafID.java
@@ -1,0 +1,106 @@
+package itc4j;
+
+import java.io.Serializable;
+
+/**
+ * LeafID
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 28/mai/2015
+ */
+final class LeafID extends ID implements Serializable {
+
+    private static final long serialVersionUID = 870626177742300327L;
+    
+    private final int value;
+
+    LeafID(int value) {
+        this.value = value;
+    }
+
+    @Override
+    ID getLeft() {
+        return null;
+    }
+
+    @Override
+    ID getRight() {
+        return null;
+    }
+
+    @Override
+    boolean isZero() {
+        return value == 0;
+    }
+
+    @Override
+    boolean isOne() {
+        return value == 1;
+    }
+
+    @Override
+    boolean isLeaf() {
+        return true;
+    }
+
+    @Override
+    ID normalize() {
+        return this;
+    }
+
+    @Override
+    ID[] split() {
+        if (isZero()) {
+            return new ID[] { IDs.zero(), IDs.zero()};
+        }
+        else { // if (isOne()) {
+            return new ID[] {
+                IDs.with(IDs.one(), IDs.zero()),
+                IDs.with(IDs.zero(), IDs.one())
+            };
+        }
+    }
+
+    @Override
+    ID sum(ID other) {
+        assert other != null;
+        if (this.isZero()) {
+            return other;
+        }
+        else if (other.isZero()) {
+            return this;
+        }
+        else {
+            throw new IllegalArgumentException("Can't sum " + this + " with " + other);
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if(!(object instanceof LeafID)) {
+            return false;
+        }
+        else {
+            LeafID other = (LeafID)object;
+            return value == other.value;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 17 * hash + this.value;
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    protected ID clone() {
+        return super.clone();
+    }
+    
+}

--- a/src/main/java/itc4j/NonLeafID.java
+++ b/src/main/java/itc4j/NonLeafID.java
@@ -1,0 +1,172 @@
+package itc4j;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * NonLeafID
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 28/mai/2015
+ */
+final class NonLeafID extends ID implements Serializable {
+
+    private static final long serialVersionUID = -5030081211956985797L;
+
+    private ID left;
+    private ID right;
+
+    NonLeafID(ID left, ID right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public ID getLeft() {
+        return left;
+    }
+
+    public ID getRight() {
+        return right;
+    }
+
+    @Override
+    boolean isOne() {
+        return false;
+    }
+
+    @Override
+    boolean isZero() {
+        return false;
+    }
+
+    @Override
+    boolean isLeaf() {
+        return false;
+    }
+
+    protected boolean hasRight() {
+        return right != null;
+    }
+
+    protected boolean hasLeft() {
+        return left != null;
+    }
+
+    @Override
+    ID normalize() {
+        normalizeChildren();
+        if (left.isZero() && right.isZero()) {
+            return IDs.zero();
+        }
+        else if (left.isOne() && right.isOne()) {
+            return IDs.one();
+        }
+        else {
+            return this;
+        }
+    }
+
+    private void normalizeChildren() {
+        if (hasRight()) {
+            normalizeRight();
+        }
+        if (hasLeft()) {
+            normalizeLeft();
+        }
+    }
+
+    private void normalizeRight() {
+        right = right.normalize();
+    }
+
+    private void normalizeLeft() {
+        left = left.normalize();
+    }
+
+    @Override
+    ID[] split() {
+        if (hasLeft() && left.isZero()) {
+            return splitWithLeftZero();
+        }
+        else if (hasRight() && getRight().isZero()) {
+            return splitWithRightZero();
+        }
+        else {
+            return new ID[] {
+                IDs.with(left.clone(), IDs.zero()),
+                IDs.with(IDs.zero(), right.clone())
+            };
+        }
+    }
+
+    private ID[] splitWithLeftZero() {
+        ID[] rightSplit = right.split();
+        return new ID[] {
+            IDs.with(IDs.zero(), rightSplit[0]),
+            IDs.with(IDs.zero(), rightSplit[1])
+        };
+    }
+
+    private ID[] splitWithRightZero() {
+        ID[] leftSplit = left.split();
+        return new ID[] {
+            IDs.with(leftSplit[0], IDs.zero()),
+            IDs.with(leftSplit[1], IDs.zero())
+        };
+    }
+
+    @Override
+    ID sum(ID other) {
+        assert other != null;
+        if (other.isZero()) {
+            return this;
+        }
+        else if (other instanceof NonLeafID) {
+            return sumNonLeaf((NonLeafID)other);
+        }
+        else {
+            throw new IllegalArgumentException("Can't sum " + this + " with 1.");
+        }
+    }
+
+    private ID sumNonLeaf(NonLeafID other) {
+        ID leftSum = left.sum(other.getLeft());
+        ID rightSum = right.sum(other.getRight());
+        ID sum = IDs.with(leftSum, rightSum);
+        return sum.normalize();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if(!(object instanceof NonLeafID)) {
+            return false;
+        }
+        else {
+            NonLeafID other = (NonLeafID)object;
+            return left.equals(other.getLeft()) && right.equals(other.getRight());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + left + ", " + right + ")";
+    }
+
+    @Override
+    public ID clone() {
+        NonLeafID clone = (NonLeafID)super.clone();
+        if (hasLeft()) {
+            clone.left = left.clone();
+        }
+        if (hasRight()) {
+            clone.right = right.clone();
+        }
+        return clone;
+    }
+    
+}

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -2,8 +2,6 @@ package itc4j;
 
 import java.io.Serializable;
 
-import static itc4j.ID.*;
-
 /**
  * @author Sina Bagherzadeh
  */
@@ -12,7 +10,7 @@ public final class Stamp implements Serializable {
     private Event event;
 
     public Stamp() {
-        id = newID_1();
+        id = IDs.one();
         event = new Event(0);
     }
 
@@ -30,7 +28,7 @@ public final class Stamp implements Serializable {
     }
 
     static Stamp[] peek(Stamp s) {
-        return new Stamp[]{new Stamp(s.id, s.event), new Stamp(newID_0(), s.event)};
+        return new Stamp[]{new Stamp(s.id, s.event), new Stamp(IDs.zero(), s.event)};
     }
 
     static Stamp join(Stamp s1, Stamp s2) {
@@ -38,18 +36,18 @@ public final class Stamp implements Serializable {
     }
 
     private static Event fill(ID id, Event event) {
-        if (id.equals(ID_0))
+        if (id.equals(IDs.zero()))
             return event;
-        if (id.equals(ID_1))
+        if (id.equals(IDs.one()))
             return new Event(Event.max(event));
         if (Event.isValuedOnly(event))
             return new Event(event.getValue());
-        if (id.getLeft() != null && id.getLeft().equals(ID_1)) {
+        if (id.getLeft() != null && id.getLeft().equals(IDs.one())) {
             Event er = fill(id.getRight(), event.getRight());
             int max = Math.max(Event.max(event.getLeft()), Event.min(er));
             return Event.norm(new Event(event.getValue(), new Event(max), er));
         }
-        if (id.getRight() != null && id.getRight().equals(ID_1)) {
+        if (id.getRight() != null && id.getRight().equals(IDs.one())) {
             Event el = fill(id.getLeft(), event.getLeft());
             int max = Math.max(Event.max(event.getRight()), Event.min(el));
             return Event.norm(new Event(event.getValue(), el, new Event(max)));
@@ -59,19 +57,19 @@ public final class Stamp implements Serializable {
     }
 
     private static GrowResult grow(ID id, Event event) {
-        if (id.equals(ID_1) && Event.isValuedOnly(event))
+        if (id.equals(IDs.one()) && Event.isValuedOnly(event))
             return new GrowResult(new Event(event.getValue() + 1), 0);
         if (Event.isValuedOnly(event)) {
             GrowResult er = grow(id, new Event(event.getValue(), new Event(0), new Event(0)));
             er.setC(er.getC() + event.maxDepth() + 1);
             return er;
         }
-        if (id.getLeft() != null && id.getLeft().equals(ID_0)) {
+        if (id.getLeft() != null && id.getLeft().equals(IDs.zero())) {
             GrowResult er = grow(id.getRight(), event.getRight());
             Event e = new Event(event.getValue(), event.getLeft(), er.getEvent());
             return new GrowResult(e, er.getC() + 1);
         }
-        if (id.getRight() != null && id.getRight().equals(ID_0)) {
+        if (id.getRight() != null && id.getRight().equals(IDs.zero())) {
             GrowResult er = grow(id.getLeft(), event.getLeft());
             Event e = new Event(event.getValue(), er.getEvent(), event.getRight());
             return new GrowResult(e, er.getC() + 1);

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -23,7 +23,7 @@ public final class Stamp implements Serializable {
 
     static Stamp[] fork(Stamp s) {
         Stamp[] result = new Stamp[2];
-        ID[] ids = ID.split(s.id);
+        ID[] ids = s.id.split();
         result[0] = new Stamp(ids[0], s.event);
         result[1] = new Stamp(ids[1], s.event);
         return result;
@@ -34,7 +34,7 @@ public final class Stamp implements Serializable {
     }
 
     static Stamp join(Stamp s1, Stamp s2) {
-        return new Stamp(ID.sum(s1.id, s2.id), Event.join(s1.event, s2.event));
+        return new Stamp(s1.id.sum(s2.id), Event.join(s1.event, s2.event));
     }
 
     private static Event fill(ID id, Event event) {

--- a/src/test/java/itc4j/IDTest.java
+++ b/src/test/java/itc4j/IDTest.java
@@ -1,16 +1,152 @@
 package itc4j;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static itc4j.ID.normalize;
+import static org.junit.Assert.*;
 
 /**
  * @author Sina Bagherzadeh
  */
 public class IDTest {
+    
+    private final ID zero = ID.newID_0();
+    private final ID one = ID.newID_1();
+    private final ID zeroZero = new ID(ID.newID_0(), ID.newID_0());
+    private final ID zeroOne = new ID(ID.newID_0(), ID.newID_1());
+    private final ID oneZero = new ID(ID.newID_1(), ID.newID_0());
+    private final ID oneOne = new ID(ID.newID_1(), ID.newID_1());
+    
+    @Test
+    public void testIsLeaf() {
+        assertTrue(zero.isLeaf());
+        assertTrue(one.isLeaf());
+        assertFalse(zeroZero.isLeaf());
+        assertFalse(zeroOne.isLeaf());
+        assertFalse(oneZero.isLeaf());
+        assertFalse(oneOne.isLeaf());
+    }
+    
+    @Test
+    public void testIsZero() {
+        assertTrue(zero.isZero());
+        assertFalse(one.isZero());
+        assertFalse(zeroZero.isZero());
+        assertFalse(zeroOne.isZero());
+        assertFalse(oneZero.isZero());
+        assertFalse(oneOne.isZero());
+    }
+    
+    @Test
+    public void testIsOne() {
+        assertFalse(zero.isOne());
+        assertTrue(one.isOne());
+        assertFalse(zeroZero.isOne());
+        assertFalse(zeroOne.isOne());
+        assertFalse(oneZero.isOne());
+        assertFalse(oneOne.isOne());
+    }
+    
+    @Test
+    public void testEquals_Leafs() {
+        assertTrue(zero.equals(zero));
+        assertFalse(zero.equals(one));
+        
+        assertTrue(one.equals(one));
+        assertFalse(one.equals(zero));
+    }
+    
+    @Test
+    public void testEquals_NonLeafs() {
+        assertTrue(zeroZero.equals(zeroZero));
+        assertTrue(zeroOne.equals(zeroOne));
+        assertTrue(oneZero.equals(oneZero));
+        assertTrue(oneOne.equals(oneOne));
+    }
 
     @Test
-    public void testNorm() {
-        Assert.assertEquals(ID.ID_1,
-                ID.norm(new ID(ID.newID_1(), new ID(ID.newID_1(), ID.newID_1()))));//norm(1, (1, 1))
+    public void testNormalize() {
+        assertEquals(zero, normalize(zero));
+        assertEquals(one, normalize(one));
+        
+        assertEquals(zero, normalize(zeroZero));
+        assertEquals(one, normalize(oneOne));
+        
+        assertEquals(zeroOne, normalize(zeroOne));
+        assertEquals(oneZero, normalize(oneZero));
+        
+        assertEquals(zero, normalize(new ID(zero, zeroZero)));
+        assertEquals(zero, normalize(new ID(zeroZero, zero)));
+        assertEquals(oneZero, normalize(new ID(one, zeroZero)));
+        assertEquals(zeroOne, normalize(new ID(zeroZero, one)));
+        
+        assertEquals(one, normalize(new ID(one, oneOne)));
+        assertEquals(one, normalize(new ID(oneOne, one)));
+        assertEquals(zeroOne, normalize(new ID(zero, oneOne)));
+        assertEquals(oneZero, normalize(new ID(oneOne, zero)));
     }
+    
+    @Test
+    public void testSplit_Leaf() {
+        // split(0) = (0, 0)
+        ID[] zeroSplit = zero.split();
+        assertEquals(zero, zeroSplit[0]);
+        assertEquals(zero, zeroSplit[1]);
+        // split(1) = ((1,0), (0,1)
+        ID[] oneSplit = one.split();
+        assertEquals(oneZero, oneSplit[0]);
+        assertEquals(zeroOne, oneSplit[1]);
+    }
+    
+    @Test
+    public void testSplit_ZeroOne() {
+        // split((0, i)) = ((0,i1), (0,i2)), where (i1, i2) = split(i)
+        ID[] splitOne = one.split();
+        ID[] expected = new ID[] {
+            new ID(zero, splitOne[0]),
+            new ID(zero, splitOne[1])
+        };
+        assertArrayEquals(expected, zeroOne.split());
+    }
+    
+    @Test
+    public void testSplit_OneZero() {
+        // split((i, 0)) = ((i1,0), (i2,0)), where (i1, i2) = split(i)
+        ID[] splitOne = one.split();
+        ID[] expected = new ID[] {
+            new ID(splitOne[0], zero),
+            new ID(splitOne[1], zero)
+        };
+        assertArrayEquals(expected, oneZero.split());
+    }
+    
+    @Test
+    public void testSplit_OneOne() {
+        // split((i1, i2)) = ((i1,0), (0,i2))
+        ID[] expected = new ID[] { oneZero, zeroOne };
+        assertArrayEquals(expected, oneOne.split());
+    }
+    
+    @Test
+    public void testSum_Leafs() {
+        assertEquals(zero, zero.sum(zero));
+        assertEquals(one, zero.sum(one));
+        assertEquals(one, one.sum(zero));
+    }
+    
+    @Test
+    public void testSum_NonLeafs() {
+        assertEquals(one, oneZero.sum(zeroOne));
+        assertEquals(one, zeroOne.sum(oneZero));
+        
+        ID expected = new ID(one, oneZero);
+        assertEquals(expected, oneZero.sum(new ID(zero, oneZero)));
+    }
+    
+    @Test
+    public void testSumOfSplit() {
+        ID[] splitOne = one.split();
+        assertEquals(one, splitOne[0].sum(splitOne[1]));
+    }
+    
 }

--- a/src/test/java/itc4j/IDTest.java
+++ b/src/test/java/itc4j/IDTest.java
@@ -2,7 +2,6 @@ package itc4j;
 
 import org.junit.Test;
 
-import static itc4j.ID.normalize;
 import static org.junit.Assert.*;
 
 /**
@@ -66,24 +65,24 @@ public class IDTest {
 
     @Test
     public void testNormalize() {
-        assertEquals(zero, normalize(zero));
-        assertEquals(one, normalize(one));
+        assertEquals(zero, zero.normalize());
+        assertEquals(one, one.normalize());
         
-        assertEquals(zero, normalize(zeroZero));
-        assertEquals(one, normalize(oneOne));
+        assertEquals(zero, zeroZero.normalize());
+        assertEquals(one, oneOne.normalize());
         
-        assertEquals(zeroOne, normalize(zeroOne));
-        assertEquals(oneZero, normalize(oneZero));
+        assertEquals(zeroOne, zeroOne.normalize());
+        assertEquals(oneZero, oneZero.normalize());
         
-        assertEquals(zero, normalize(new ID(zero, zeroZero)));
-        assertEquals(zero, normalize(new ID(zeroZero, zero)));
-        assertEquals(oneZero, normalize(new ID(one, zeroZero)));
-        assertEquals(zeroOne, normalize(new ID(zeroZero, one)));
+        assertEquals(zero, new ID(zero, zeroZero).normalize());
+        assertEquals(zero, new ID(zeroZero, zero).normalize());
+        assertEquals(oneZero, new ID(one, zeroZero).normalize());
+        assertEquals(zeroOne, new ID(zeroZero, one).normalize());
         
-        assertEquals(one, normalize(new ID(one, oneOne)));
-        assertEquals(one, normalize(new ID(oneOne, one)));
-        assertEquals(zeroOne, normalize(new ID(zero, oneOne)));
-        assertEquals(oneZero, normalize(new ID(oneOne, zero)));
+        assertEquals(one, new ID(one, oneOne).normalize());
+        assertEquals(one, new ID(oneOne, one).normalize());
+        assertEquals(zeroOne, new ID(zero, oneOne).normalize());
+        assertEquals(oneZero, new ID(oneOne, zero).normalize());
     }
     
     @Test

--- a/src/test/java/itc4j/IDTest.java
+++ b/src/test/java/itc4j/IDTest.java
@@ -9,12 +9,12 @@ import static org.junit.Assert.*;
  */
 public class IDTest {
     
-    private final ID zero = ID.newID_0();
-    private final ID one = ID.newID_1();
-    private final ID zeroZero = new ID(ID.newID_0(), ID.newID_0());
-    private final ID zeroOne = new ID(ID.newID_0(), ID.newID_1());
-    private final ID oneZero = new ID(ID.newID_1(), ID.newID_0());
-    private final ID oneOne = new ID(ID.newID_1(), ID.newID_1());
+    private final ID zero = IDs.zero();
+    private final ID one = IDs.one();
+    private final ID zeroZero = IDs.with(IDs.zero(), IDs.zero());
+    private final ID zeroOne = IDs.with(IDs.zero(), IDs.one());
+    private final ID oneZero = IDs.with(IDs.one(), IDs.zero());
+    private final ID oneOne = IDs.with(IDs.one(), IDs.one());
     
     @Test
     public void testIsLeaf() {
@@ -74,15 +74,15 @@ public class IDTest {
         assertEquals(zeroOne, zeroOne.normalize());
         assertEquals(oneZero, oneZero.normalize());
         
-        assertEquals(zero, new ID(zero, zeroZero).normalize());
-        assertEquals(zero, new ID(zeroZero, zero).normalize());
-        assertEquals(oneZero, new ID(one, zeroZero).normalize());
-        assertEquals(zeroOne, new ID(zeroZero, one).normalize());
+        assertEquals(zero, IDs.with(zero, zeroZero).normalize());
+        assertEquals(zero, IDs.with(zeroZero, zero).normalize());
+        assertEquals(oneZero, IDs.with(one, zeroZero).normalize());
+        assertEquals(zeroOne, IDs.with(zeroZero, one).normalize());
         
-        assertEquals(one, new ID(one, oneOne).normalize());
-        assertEquals(one, new ID(oneOne, one).normalize());
-        assertEquals(zeroOne, new ID(zero, oneOne).normalize());
-        assertEquals(oneZero, new ID(oneOne, zero).normalize());
+        assertEquals(one, IDs.with(one, oneOne).normalize());
+        assertEquals(one, IDs.with(oneOne, one).normalize());
+        assertEquals(zeroOne, IDs.with(zero, oneOne).normalize());
+        assertEquals(oneZero, IDs.with(oneOne, zero).normalize());
     }
     
     @Test
@@ -102,8 +102,8 @@ public class IDTest {
         // split((0, i)) = ((0,i1), (0,i2)), where (i1, i2) = split(i)
         ID[] splitOne = one.split();
         ID[] expected = new ID[] {
-            new ID(zero, splitOne[0]),
-            new ID(zero, splitOne[1])
+            IDs.with(zero, splitOne[0]),
+            IDs.with(zero, splitOne[1])
         };
         assertArrayEquals(expected, zeroOne.split());
     }
@@ -113,8 +113,8 @@ public class IDTest {
         // split((i, 0)) = ((i1,0), (i2,0)), where (i1, i2) = split(i)
         ID[] splitOne = one.split();
         ID[] expected = new ID[] {
-            new ID(splitOne[0], zero),
-            new ID(splitOne[1], zero)
+            IDs.with(splitOne[0], zero),
+            IDs.with(splitOne[1], zero)
         };
         assertArrayEquals(expected, oneZero.split());
     }
@@ -138,8 +138,8 @@ public class IDTest {
         assertEquals(one, oneZero.sum(zeroOne));
         assertEquals(one, zeroOne.sum(oneZero));
         
-        ID expected = new ID(one, oneZero);
-        assertEquals(expected, oneZero.sum(new ID(zero, oneZero)));
+        ID expected = IDs.with(one, oneZero);
+        assertEquals(expected, oneZero.sum(IDs.with(zero, oneZero)));
     }
     
     @Test

--- a/src/test/java/itc4j/StampTest.java
+++ b/src/test/java/itc4j/StampTest.java
@@ -34,7 +34,7 @@ public class StampTest {
         System.out.println("join2 = " + join2);
         Stamp event3 = event(join2);
         System.out.println("event3 = " + event3);
-        Assert.assertEquals(new Stamp(new ID(ID.newID_1(), ID.newID_0()), new Event(2)), event3);
+        Assert.assertEquals(new Stamp(IDs.with(IDs.one(), IDs.zero()), new Event(2)), event3);
     }
 
     @Test


### PR DESCRIPTION
Splits `ID` class into two subclasses: `LeafID` and `NonLeafID`.
- `LeafID` class represents 0 and 1 IDs. These IDs don't have `right` and `left` fields.
- `NonLeafID` class represents IDs with children (for example: `(1, (0, 1)`). These IDs don't have a `value` field.

I decided to split `ID` into two classes because it was clear that instances of this class could have one of two different states: either they had a `value` field, or they had `right` and `left` fields. There were also many `if`s checking the state of the ID, which also led to the conclusion that this class should be split into two classes.

`ID` class methods `norm`, `split` and `sum` were turned into instance methods, so that each subclass could implement its own behaviour.

Beside this changes, I:
- added more tests for IDs;
- created `IDs` factory class and moved (and renamed) `newID_0` and `newID_1` factory methods to this class.
