### PR TITLE
Event class refactor

### DIFF
--- a/src/main/java/itc4j/Event.java
+++ b/src/main/java/itc4j/Event.java
@@ -1,227 +1,49 @@
 package itc4j;
 
-import java.io.Serializable;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * @author Sina Bagherzadeh
  */
-public final class Event implements Serializable, Cloneable {
-
-    private static final long serialVersionUID = -9008822740100066140L;
-
-    private Event left;
-    private Event right;
-    private final int value;
+public abstract class Event implements Cloneable {
 
     Event() {
-        value = 0;
-        this.left = null;
-        this.right = null;
+        
     }
 
-    Event(int value) {
-        this.value = value;
-        this.left = null;
-        this.right = null;
-    }
+    abstract int getValue();
 
-    Event(int value, Event left, Event right) {
-        this.value = value;
-        this.left = left;
-        this.right = right;
-    }
+    abstract Event getLeft();
 
-    Event getLeft() {
-        return left;
-    }
+    abstract Event getRight();
 
-    Event getRight() {
-        return right;
-    }
+    abstract int min();
 
-    int getValue() {
-        return value;
-    }
+    abstract int max();
 
-    int min() {
-        if (isLeaf()) {
-            return value;
-        }
-        else {
-            int min = Math.min(left.min(), right.min());
-            return value + min;
-        }
-    }
-
-    int max() {
-        if (isLeaf()) {
-            return value;
-        }
-        else {
-            int max = Math.max(left.max(), right.max());
-            return value + max;
-        }
-    }
-
-    public int maxDepth() {
+    final int maxDepth() {
         return maxDepth(0);
     }
 
-    private int maxDepth(int depth) {
-        if (isLeaf()) {
-            return depth;
-        }
-        else {
-            int leftDepth = left.maxDepth(depth + 1);
-            int rightDepth = right.maxDepth(depth + 1);
-            return Math.max(leftDepth, rightDepth);
-        }
-    }
+    protected abstract int maxDepth(int depth);
     
-    boolean isLeaf() {
-        return left == null && right == null;
-    }
+    abstract boolean isLeaf();
 
-    Event lift(int m) {
-        return new Event(value + m, left, right);
-    }
+    abstract Event lift(int m);
 
-    Event sink(int m) {
-        return new Event(value - m, left, right);
-    }
+    abstract Event sink(int m);
 
-    public Event normalize() {
-        if (isLeaf()) {
-            return this;
-        }
-        else {
-            return normalizeNonLeaf();
-        }
-    }
+    abstract public Event normalize();
 
-    private Event normalizeNonLeaf() {
-        if (left.isLeaf() && right.isLeaf() && left.value == right.value) {
-            return new Event(value + left.value);
-        }
-        else {
-            int min = Math.min(left.min(), right.min());
-            return new Event(value + min, left.sink(min), right.sink(min));
-        }
-    }
+    abstract boolean leq(Event other);
 
-    boolean leq(Event other) {
-        if (isLeaf()) {
-            return value <= other.value;
-        }
-        else if (other.isLeaf()) {
-            return value <= other.value &&
-                   liftedLeft().leq(other) &&
-                   liftedRight().leq(other);
-        }
-        else {
-            return leqNonLeafs(other);
-        }
-    }
-
-    private Event liftedRight() {
-        return right.lift(value);
-    }
-
-    private Event liftedLeft() {
-        return left.lift(value);
-    }
-
-    private boolean leqNonLeafs(Event other) {
-        return value <= other.value &&
-               liftedLeft().leq(other.liftedLeft()) &&
-               liftedRight().leq(other.liftedRight());
-    }
-
-    Event join(Event other) {
-        if (isLeaf()) {
-            return joinLeaf(other);
-        }
-        else {
-            return joinNonLeaf(other);
-        }
-    }
-
-    private Event joinLeaf(Event other) {
-        if (other.isLeaf()) {
-            return new Event(Math.max(value, other.value));
-        }
-        else {
-            return new Event(value, new Event(0), new Event(0)).join(other);
-        }
-    }
-    
-    private Event joinNonLeaf(Event other) {
-        if (other.isLeaf()) {
-            return join(new Event(other.value, new Event(0), new Event(0)));
-        }
-        else {
-            if (value > other.value)
-                return other.join(this);
-            else {
-                return new Event(value, leftJoin(other), rightJoin(other)).normalize();
-            }
-        }
-    }
-
-    private Event leftJoin(Event other) {
-        Event otherLiftedLeft = other.left.lift(other.value - value);
-        return left.join(otherLiftedLeft);
-    }
-
-    private Event rightJoin(Event other) {
-        Event otherLiftedRight = other.right.lift(other.value - value);
-        return right.join(otherLiftedRight);
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (!(object instanceof Event)) {
-            return false;
-        }
-        else {
-            Event other = (Event)object;
-            return value == other.value &&
-                   Objects.equals(left, other.left) &&
-                   Objects.equals(right, other.right);
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 3;
-        hash = 23 * hash + Objects.hashCode(left);
-        hash = 23 * hash + Objects.hashCode(right);
-        hash = 23 * hash + this.value;
-        return hash;
-    }
-
-    @Override
-    public String toString() {
-        if (isLeaf()) {
-            return String.valueOf(value);
-        }
-        else {
-            return "(" + value + ", " + left + ", " + right + ")";
-        }
-    }
+    abstract Event join(Event other);
 
     @Override
     public Event clone() {
         try {
-            Event clone = (Event)super.clone();
-            if (right != null)
-                clone.right = right.clone();
-            if (left != null)
-                clone.left = left.clone();
-            return clone;
+            return (Event)super.clone();
         }
         catch(CloneNotSupportedException ex) {
             Logger.getLogger(Event.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/itc4j/Events.java
+++ b/src/main/java/itc4j/Events.java
@@ -1,0 +1,26 @@
+
+package itc4j;
+
+/**
+ * Events
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 29/mai/2015
+ */
+public final class Events {
+    
+    public static Event zero() {
+        return with(0);
+    }
+    
+    public static Event with(int value) {
+        return new LeafEvent(value);
+    }
+    
+    public static Event with(int value, Event left, Event right) {
+        return new NonLeafEvent(value, left, right);
+    }
+
+    private Events() { }
+    
+}

--- a/src/main/java/itc4j/LeafEvent.java
+++ b/src/main/java/itc4j/LeafEvent.java
@@ -1,0 +1,118 @@
+package itc4j;
+
+import java.io.Serializable;
+
+/**
+ * LeafEvent
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 29/mai/2015
+ */
+final class LeafEvent extends Event implements Serializable, Cloneable {
+
+    private static final long serialVersionUID = -7441138365249091187L;
+    
+    private final int value;
+
+    LeafEvent() {
+        value = 0;
+    }
+
+    LeafEvent(int value) {
+        this.value = value;
+    }
+
+    @Override
+    int getValue() {
+        return value;
+    }
+
+    @Override
+    Event getLeft() {
+        return null;
+    }
+
+    @Override
+    Event getRight() {
+        return null;
+    }
+
+    @Override
+    int max() {
+        return value;
+    }
+
+    @Override
+    int min() {
+        return value;
+    }
+
+    @Override
+    protected int maxDepth(int depth) {
+        return depth;
+    }
+
+    @Override
+    boolean isLeaf() {
+        return true;
+    }
+
+    @Override
+    Event lift(int m) {
+        return new LeafEvent(value + m);
+    }
+
+    @Override
+    Event sink(int m) {
+        return new LeafEvent(value - m);
+    }
+
+    @Override
+    public Event normalize() {
+        return this;
+    }
+
+    @Override
+    boolean leq(Event other) {
+        return value <= other.getValue();
+    }
+
+    @Override
+    Event join(Event other) {
+        if (other.isLeaf()) {
+            return new LeafEvent(Math.max(value, other.getValue()));
+        }
+        else {
+            return Events.with(value, Events.zero(), Events.zero()).join(other);
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if(!(object instanceof LeafEvent)) {
+            return false;
+        }
+        else {
+            final LeafEvent other = (LeafEvent)object;
+            return this.value == other.value;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 41 * hash + this.value;
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public Event clone() {
+        return super.clone();
+    }
+    
+}

--- a/src/main/java/itc4j/NonLeafEvent.java
+++ b/src/main/java/itc4j/NonLeafEvent.java
@@ -1,0 +1,177 @@
+
+package itc4j;
+
+import java.util.Objects;
+
+/**
+ * NonLeafEvent
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 29/mai/2015
+ */
+final class NonLeafEvent extends Event {
+    
+    private final int value;
+    private Event left;
+    private Event right;
+
+    NonLeafEvent(int value, Event left, Event right) {
+        this.value = value;
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    int getValue() {
+        return value;
+    }
+
+    Event getLeft() {
+        return left;
+    }
+
+    Event getRight() {
+        return right;
+    }
+
+    @Override
+    int min() {
+        int min = Math.min(left.min(), right.min());
+        return value + min;
+    }
+
+    @Override
+    int max() {
+        int max = Math.max(left.max(), right.max());
+        return value + max;
+    }
+
+    @Override
+    protected int maxDepth(int depth) {
+        int leftDepth = left.maxDepth(depth + 1);
+        int rightDepth = right.maxDepth(depth + 1);
+        return Math.max(leftDepth, rightDepth);
+    }
+
+    @Override
+    boolean isLeaf() {
+        return false;
+    }
+
+    @Override
+    Event lift(int m) {
+        return Events.with(value + m, left, right);
+    }
+
+    @Override
+    Event sink(int m) {
+        return Events.with(value - m, left, right);
+    }
+
+    @Override
+    public Event normalize() {
+        if (left.isLeaf() && right.isLeaf() && left.getValue() == right.getValue()) {
+            return Events.with(value + left.getValue());
+        }
+        else {
+            int min = Math.min(left.min(), right.min());
+            return Events.with(value + min, left.sink(min), right.sink(min));
+        }
+    }
+
+    @Override
+    boolean leq(Event other) {
+        if (other.isLeaf()) {
+            return leqLeaf(other);
+        }
+        else {
+            return leqNonLeafs(other);
+        }
+    }
+
+    private boolean leqLeaf(Event other) {
+        return value <= other.getValue() &&
+               liftedLeft(this).leq(other) &&
+               liftedRight(this).leq(other);
+    }
+
+    private static Event liftedLeft(Event event) {
+        return event.getLeft().lift(event.getValue());
+    }
+
+    private static Event liftedRight(Event event) {
+        return event.getRight().lift(event.getValue());
+    }
+
+    private boolean leqNonLeafs(Event other) {
+        return value <= other.getValue() &&
+               liftedLeft(this).leq(liftedLeft(other)) &&
+               liftedRight(this).leq(liftedRight(other));
+    }
+
+    @Override
+    Event join(Event other) {
+        if (other.isLeaf()) {
+            return join(Events.with(other.getValue(), Events.zero(), Events.zero()));
+        }
+        else {
+            return joinNonLeaf(other);
+        }
+    }
+
+    private Event joinNonLeaf(Event other) {
+        if (value > other.getValue()) {
+            return other.join(this);
+        }
+        else {
+            Event join = Events.with(value, leftJoin(other), rightJoin(other));
+            return join.normalize();
+        }
+    }
+
+    private Event leftJoin(Event other) {
+        Event otherLiftedLeft = other.getLeft().lift(other.getValue() - value);
+        return left.join(otherLiftedLeft);
+    }
+
+    private Event rightJoin(Event other) {
+        Event otherLiftedRight = other.getRight().lift(other.getValue() - value);
+        return right.join(otherLiftedRight);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof NonLeafEvent)) {
+            return false;
+        }
+        else {
+            NonLeafEvent other = (NonLeafEvent)object;
+            return value == other.value &&
+                   Objects.equals(left, other.left) &&
+                   Objects.equals(right, other.right);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 37 * hash + value;
+        hash = 37 * hash + left.hashCode();
+        hash = 37 * hash + right.hashCode();
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + value + ", " + left + ", " + right + ")";
+    }
+
+    @Override
+    public Event clone() {
+        NonLeafEvent clone = (NonLeafEvent)super.clone();
+        clone.right = right.clone();
+        clone.left = left.clone();
+        return clone;
+    }
+
+}

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -11,7 +11,7 @@ public final class Stamp implements Serializable {
 
     public Stamp() {
         id = IDs.one();
-        event = new Event(0);
+        event = Events.zero();
     }
 
     Stamp(ID id, Event event) {
@@ -39,48 +39,48 @@ public final class Stamp implements Serializable {
         if (id.equals(IDs.zero()))
             return event;
         if (id.equals(IDs.one()))
-            return new Event(event.max());
+            return Events.with(event.max());
         if (event.isLeaf())
-            return new Event(event.getValue());
+            return Events.with(event.getValue());
         if (id.getLeft() != null && id.getLeft().equals(IDs.one())) {
             Event er = fill(id.getRight(), event.getRight());
             int max = Math.max(event.getLeft().max(), er.min());
-            return new Event(event.getValue(), new Event(max), er).normalize();
+            return Events.with(event.getValue(), Events.with(max), er).normalize();
         }
         if (id.getRight() != null && id.getRight().equals(IDs.one())) {
             Event el = fill(id.getLeft(), event.getLeft());
             int max = Math.max(event.getRight().max(), el.min());
-            return new Event(event.getValue(), el, new Event(max)).normalize();
+            return Events.with(event.getValue(), el, Events.with(max)).normalize();
         }
-        return new Event(event.getValue(), fill(id.getLeft(), event.getLeft()),
+        return Events.with(event.getValue(), fill(id.getLeft(), event.getLeft()),
                 fill(id.getRight(), event.getRight())).normalize();
     }
 
     private static GrowResult grow(ID id, Event event) {
         if (id.equals(IDs.one()) && event.isLeaf())
-            return new GrowResult(new Event(event.getValue() + 1), 0);
+            return new GrowResult(Events.with(event.getValue() + 1), 0);
         if (event.isLeaf()) {
-            GrowResult er = grow(id, new Event(event.getValue(), new Event(0), new Event(0)));
+            GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
             er.setC(er.getC() + event.maxDepth() + 1);
             return er;
         }
         if (id.getLeft() != null && id.getLeft().equals(IDs.zero())) {
             GrowResult er = grow(id.getRight(), event.getRight());
-            Event e = new Event(event.getValue(), event.getLeft(), er.getEvent());
+            Event e = Events.with(event.getValue(), event.getLeft(), er.getEvent());
             return new GrowResult(e, er.getC() + 1);
         }
         if (id.getRight() != null && id.getRight().equals(IDs.zero())) {
             GrowResult er = grow(id.getLeft(), event.getLeft());
-            Event e = new Event(event.getValue(), er.getEvent(), event.getRight());
+            Event e = Events.with(event.getValue(), er.getEvent(), event.getRight());
             return new GrowResult(e, er.getC() + 1);
         }
         GrowResult left = grow(id.getLeft(), event.getLeft());
         GrowResult right = grow(id.getRight(), event.getRight());
         if (left.getC() < right.getC()) {
-            Event e = new Event(event.getValue(), left.getEvent(), event.getRight());
+            Event e = Events.with(event.getValue(), left.getEvent(), event.getRight());
             return new GrowResult(e, left.getC() + 1);
         } else {
-            Event e = new Event(event.getValue(), event.getLeft(), right.getEvent());
+            Event e = Events.with(event.getValue(), event.getLeft(), right.getEvent());
             return new GrowResult(e, right.getC() + 1);
         }
     }

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -32,34 +32,34 @@ public final class Stamp implements Serializable {
     }
 
     static Stamp join(Stamp s1, Stamp s2) {
-        return new Stamp(s1.id.sum(s2.id), Event.join(s1.event, s2.event));
+        return new Stamp(s1.id.sum(s2.id), s1.event.join(s2.event));
     }
 
     private static Event fill(ID id, Event event) {
         if (id.equals(IDs.zero()))
             return event;
         if (id.equals(IDs.one()))
-            return new Event(Event.max(event));
-        if (Event.isValuedOnly(event))
+            return new Event(event.max());
+        if (event.isLeaf())
             return new Event(event.getValue());
         if (id.getLeft() != null && id.getLeft().equals(IDs.one())) {
             Event er = fill(id.getRight(), event.getRight());
-            int max = Math.max(Event.max(event.getLeft()), Event.min(er));
-            return Event.norm(new Event(event.getValue(), new Event(max), er));
+            int max = Math.max(event.getLeft().max(), er.min());
+            return new Event(event.getValue(), new Event(max), er).normalize();
         }
         if (id.getRight() != null && id.getRight().equals(IDs.one())) {
             Event el = fill(id.getLeft(), event.getLeft());
-            int max = Math.max(Event.max(event.getRight()), Event.min(el));
-            return Event.norm(new Event(event.getValue(), el, new Event(max)));
+            int max = Math.max(event.getRight().max(), el.min());
+            return new Event(event.getValue(), el, new Event(max)).normalize();
         }
-        return Event.norm(new Event(event.getValue(), fill(id.getLeft(), event.getLeft()),
-                fill(id.getRight(), event.getRight())));
+        return new Event(event.getValue(), fill(id.getLeft(), event.getLeft()),
+                fill(id.getRight(), event.getRight())).normalize();
     }
 
     private static GrowResult grow(ID id, Event event) {
-        if (id.equals(IDs.one()) && Event.isValuedOnly(event))
+        if (id.equals(IDs.one()) && event.isLeaf())
             return new GrowResult(new Event(event.getValue() + 1), 0);
-        if (Event.isValuedOnly(event)) {
+        if (event.isLeaf()) {
             GrowResult er = grow(id, new Event(event.getValue(), new Event(0), new Event(0)));
             er.setC(er.getC() + event.maxDepth() + 1);
             return er;
@@ -134,7 +134,7 @@ public final class Stamp implements Serializable {
     }
 
     public static boolean leq(Stamp s1, Stamp s2) {
-        return Event.leq(s1.event, s2.event);
+        return s1.event.leq(s2.event);
     }
 
 }

--- a/src/test/java/itc4j/EventTest.java
+++ b/src/test/java/itc4j/EventTest.java
@@ -12,16 +12,16 @@ import static org.junit.Assert.assertTrue;
  */
 public class EventTest {
     
-    private final Event event1 = new Event(1);
-    private final Event event2 = new Event(2, new Event(0), new Event(2));
-    private final Event event3 = new Event(3);
+    private final Event event1 = Events.with(1);
+    private final Event event2 = Events.with(2, Events.with(0), Events.with(2));
+    private final Event event3 = Events.with(3);
     
     @Test
     public void testEquals() {
-        assertTrue(event1.equals(new Event(1)));
+        assertTrue(event1.equals(Events.with(1)));
         assertFalse(event1.equals(event2));
         
-        assertTrue(event2.equals(new Event(2, new Event(0), new Event(2))));
+        assertTrue(event2.equals(Events.with(2, Events.with(0), Events.with(2))));
     }
     
     @Test
@@ -64,13 +64,13 @@ public class EventTest {
     public void testNormalize() {
         Event expected, event;
         
-        expected = new Event(3);
-        event = new Event(2, new Event(1), new Event(1));
+        expected = Events.with(3);
+        event = Events.with(2, Events.with(1), Events.with(1));
         // norm((2, 1, 1)) == 3
         assertEquals(expected, event.normalize());
         
-        expected = new Event(4, new Event(0, new Event(1), new Event(0)), new Event(1));
-        event = new Event(2, new Event(2, new Event(1), new Event(0)), new Event(3));
+        expected = Events.with(4, Events.with(0, Events.with(1), Events.with(0)), Events.with(1));
+        event = Events.with(2, Events.with(2, Events.with(1), Events.with(0)), Events.with(3));
         // norm((2, (2, 1, 0), 3)) == (4, (0, 1, 0), 1)
         assertEquals(expected, event.normalize());
     }
@@ -102,7 +102,7 @@ public class EventTest {
         assertEquals(event2, event1.join(event2));
         assertEquals(event3, event1.join(event3));
         
-        Event expected = new Event(3, new Event(0), new Event(1));
+        Event expected = Events.with(3, Events.with(0), Events.with(1));
         assertEquals(expected, event2.join(event3));
     }
     

--- a/src/test/java/itc4j/EventTest.java
+++ b/src/test/java/itc4j/EventTest.java
@@ -3,18 +3,112 @@ package itc4j;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static itc4j.Event.norm;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sina Bagherzadeh
  */
 public class EventTest {
+    
+    private final Event event1 = new Event(1);
+    private final Event event2 = new Event(2, new Event(0), new Event(2));
+    private final Event event3 = new Event(3);
+    
+    @Test
+    public void testEquals() {
+        assertTrue(event1.equals(new Event(1)));
+        assertFalse(event1.equals(event2));
+        
+        assertTrue(event2.equals(new Event(2, new Event(0), new Event(2))));
+    }
+    
+    @Test
+    public void testIsLeaf() {
+        assertTrue(event1.isLeaf());
+        assertFalse(event2.isLeaf());
+    }
+    
+    @Test
+    public void testMin() {
+        assertIntEquals(1, event1.min());
+        assertIntEquals(2, event2.min());
+    }
+    
+    @Test
+    public void testMax() {
+        assertIntEquals(1, event1.max());
+        assertIntEquals(4, event2.max());
+    }
+    
+    @Test
+    public void testMaxDepth() {
+        assertIntEquals(0, event1.maxDepth());
+        assertIntEquals(1, event2.maxDepth());
+    }
+    
+    @Test
+    public void testLift() {
+        assertIntEquals(2, event1.lift(1).getValue());
+        assertIntEquals(3, event2.lift(1).getValue());
+    }
+    
+    @Test
+    public void testSink() {
+        assertIntEquals(0, event1.sink(1).getValue());
+        assertIntEquals(1, event2.sink(1).getValue());
+    }
 
     @Test
-    public void testNorm() {
-        Assert.assertEquals(new Event(3),
-                norm(new Event(2, new Event(1), new Event(1))));//norm(2, 1, 1)
-        Assert.assertEquals(new Event(4, new Event(0, new Event(1), new Event(0)), new Event(1)), //(4, (0, 1, 0), 1)==
-                norm(new Event(2, new Event(2, new Event(1), new Event(0)), new Event(3))));//norm(2, (2, 1, 0), 3)
+    public void testNormalize() {
+        Event expected, event;
+        
+        expected = new Event(3);
+        event = new Event(2, new Event(1), new Event(1));
+        // norm((2, 1, 1)) == 3
+        assertEquals(expected, event.normalize());
+        
+        expected = new Event(4, new Event(0, new Event(1), new Event(0)), new Event(1));
+        event = new Event(2, new Event(2, new Event(1), new Event(0)), new Event(3));
+        // norm((2, (2, 1, 0), 3)) == (4, (0, 1, 0), 1)
+        assertEquals(expected, event.normalize());
+    }
+    
+    @Test
+    public void testNormalize_NormalizedEvents() {
+        assertEquals(event1, event1.normalize());
+        assertEquals(event2, event2.normalize());
+    }
+    
+    @Test
+    public void testLeq() {
+        assertTrue(event1.leq(event1));
+        assertTrue(event1.leq(event2));
+        assertTrue(event1.leq(event3));
+        
+        assertFalse(event2.leq(event1));
+        assertTrue(event2.leq(event2));
+        assertFalse(event2.leq(event3));
+        
+        assertFalse(event3.leq(event1));
+        assertFalse(event3.leq(event2));
+        assertTrue(event3.leq(event3));
+    }
+    
+    @Test
+    public void testJoin() {
+        assertEquals(event1, event1.join(event1));
+        assertEquals(event2, event1.join(event2));
+        assertEquals(event3, event1.join(event3));
+        
+        Event expected = new Event(3, new Event(0), new Event(1));
+        assertEquals(expected, event2.join(event3));
+    }
+    
+    private static void assertIntEquals(int expected, int actual) {
+        long lExpected = expected;
+        long lActual = actual;
+        Assert.assertEquals(lExpected, lActual);
     }
 }

--- a/src/test/java/itc4j/StampTest.java
+++ b/src/test/java/itc4j/StampTest.java
@@ -34,7 +34,7 @@ public class StampTest {
         System.out.println("join2 = " + join2);
         Stamp event3 = event(join2);
         System.out.println("event3 = " + event3);
-        Assert.assertEquals(new Stamp(IDs.with(IDs.one(), IDs.zero()), new Event(2)), event3);
+        Assert.assertEquals(new Stamp(IDs.with(IDs.one(), IDs.zero()), Events.with(2)), event3);
     }
 
     @Test


### PR DESCRIPTION
Splits `Event` class into two subclasses: `LeafEvent` and `NonLeafEvent`.
- `LeafEvent` class represents Events that only have a value (i.e. they don't have children).
- `NonLeafEvent` class represents Events with children (for example: `(2, 0, 1)`).

I decided to split this class too because, like `ID` class, the `Event` class had a lot of `if`s checking whether an Event had children to decide which kind of behaviour to follow.

Like I did with IDs, I also turned `Event` class methods into instance methods, created `Events` factory class and added more tests for Events.
