### PR TITLE
Stamp class refactor and general clean-up

### DIFF
--- a/src/main/java/itc4j/Event.java
+++ b/src/main/java/itc4j/Event.java
@@ -1,12 +1,9 @@
 package itc4j;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 /**
  * @author Sina Bagherzadeh
  */
-abstract class Event implements Cloneable {
+abstract class Event {
 
     Event() {
         
@@ -39,16 +36,5 @@ abstract class Event implements Cloneable {
     abstract boolean leq(Event other);
 
     abstract Event join(Event other);
-
-    @Override
-    protected Event clone() {
-        try {
-            return (Event)super.clone();
-        }
-        catch(CloneNotSupportedException ex) {
-            Logger.getLogger(Event.class.getName()).log(Level.SEVERE, null, ex);
-            return null;
-        }
-    }
 
 }

--- a/src/main/java/itc4j/Event.java
+++ b/src/main/java/itc4j/Event.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 /**
  * @author Sina Bagherzadeh
  */
-public abstract class Event implements Cloneable {
+abstract class Event implements Cloneable {
 
     Event() {
         
@@ -34,14 +34,14 @@ public abstract class Event implements Cloneable {
 
     abstract Event sink(int m);
 
-    abstract public Event normalize();
+    abstract Event normalize();
 
     abstract boolean leq(Event other);
 
     abstract Event join(Event other);
 
     @Override
-    public Event clone() {
+    protected Event clone() {
         try {
             return (Event)super.clone();
         }

--- a/src/main/java/itc4j/Events.java
+++ b/src/main/java/itc4j/Events.java
@@ -1,4 +1,3 @@
-
 package itc4j;
 
 /**
@@ -7,17 +6,17 @@ package itc4j;
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */
-public final class Events {
+final class Events {
     
-    public static Event zero() {
+    static Event zero() {
         return with(0);
     }
     
-    public static Event with(int value) {
+    static Event with(int value) {
         return new LeafEvent(value);
     }
     
-    public static Event with(int value, Event left, Event right) {
+    static Event with(int value, Event left, Event right) {
         return new NonLeafEvent(value, left, right);
     }
 

--- a/src/main/java/itc4j/Filler.java
+++ b/src/main/java/itc4j/Filler.java
@@ -1,0 +1,72 @@
+
+package itc4j;
+
+/**
+ * Filler
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 29/mai/2015
+ */
+final class Filler {
+
+    static Event fill(ID id, Event event) {
+        if (id.isLeaf()) {
+            return fillWithLeafID(id, event);
+        }
+        else if (event.isLeaf()) {
+            return event;
+        }
+        else {
+            return fillNonLeafs(id, event);
+        }
+    }
+    
+    private static Event fillWithLeafID(ID leafID, Event event) {
+        if (leafID.isZero()) {
+            return event;
+        }
+        else {
+            return Events.with(event.max());
+        }
+    }
+
+    private static Event fillNonLeafs(ID id, Event event) {
+        if (id.getLeft().isOne()) {
+            return fillLeftOneID(id, event);
+        }
+        else if (id.getRight().isOne()) {
+            return fillRightOneID(id, event);
+        }
+        else {
+            return fillLeftRight(id, event);
+        }
+    }
+
+    private static Event fillLeftOneID(ID id, Event event) {
+        Event filledRight = fillRight(id, event);
+        int max = Math.max(event.getLeft().max(), filledRight.min());
+        return Events.with(event.getValue(), Events.with(max), filledRight).normalize();
+    }
+
+    private static Event fillRight(ID id, Event event) {
+        return fill(id.getRight(), event.getRight());
+    }
+
+    private static Event fillRightOneID(ID id, Event event) {
+        Event filledLeft = fillLeft(id, event);
+        int max = Math.max(event.getRight().max(), filledLeft.min());
+        return Events.with(event.getValue(), filledLeft, Events.with(max)).normalize();
+    }
+
+    private static Event fillLeft(ID id, Event event) {
+        return fill(id.getLeft(), event.getLeft());
+    }
+
+    private static Event fillLeftRight(ID id, Event event) {
+        return Events.with(event.getValue(), fillLeft(id, event), fillRight(id, event))
+                .normalize();
+    }
+
+    private  Filler() { }
+    
+}

--- a/src/main/java/itc4j/Filler.java
+++ b/src/main/java/itc4j/Filler.java
@@ -4,6 +4,7 @@ package itc4j;
 /**
  * Filler
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */

--- a/src/main/java/itc4j/GrowResult.java
+++ b/src/main/java/itc4j/GrowResult.java
@@ -6,23 +6,23 @@ package itc4j;
 final class GrowResult {
     
     private final Event event;
-    private int c;
+    private int cost;
 
-    GrowResult(Event event, int c) {
+    GrowResult(Event event, int cost) {
         this.event = event;
-        this.c = c;
+        this.cost = cost;
     }
 
     Event getEvent() {
         return event;
     }
 
-    int getC() {
-        return c;
+    int getCost() {
+        return cost;
     }
 
-    void setC(int c) {
-        this.c = c;
+    void setCost(int cost) {
+        this.cost = cost;
     }
     
 }

--- a/src/main/java/itc4j/GrowResult.java
+++ b/src/main/java/itc4j/GrowResult.java
@@ -1,28 +1,28 @@
 package itc4j;
 
-import java.io.Serializable;
-
 /**
  * @author Sina Bagherzadeh
  */
-public final class GrowResult implements Serializable {
-    private Event event;
+final class GrowResult {
+    
+    private final Event event;
     private int c;
 
-    public GrowResult(Event event, int c) {
+    GrowResult(Event event, int c) {
         this.event = event;
         this.c = c;
     }
 
-    public Event getEvent() {
+    Event getEvent() {
         return event;
     }
 
-    public int getC() {
+    int getC() {
         return c;
     }
 
-    public void setC(int c) {
+    void setC(int c) {
         this.c = c;
     }
+    
 }

--- a/src/main/java/itc4j/Grower.java
+++ b/src/main/java/itc4j/Grower.java
@@ -10,31 +10,82 @@ package itc4j;
 final class Grower {
 
     static GrowResult grow(ID id, Event event) {
-        if (id.equals(IDs.one()) && event.isLeaf())
+        if (id.isLeaf()) {
+            return growLeafID(id, event);
+        }
+        else {
+            return growNonLeafID(id, event);
+        }
+    }
+    
+    private static GrowResult growLeafID(ID id, Event event) {
+        if (id.isOne() && event.isLeaf()) {
             return new GrowResult(Events.with(event.getValue() + 1), 0);
+        }
+        else {
+            throw new IllegalArgumentException("Illegal arguments: " + id + " and " + event);
+        }
+    }
+    
+    private static GrowResult growNonLeafID(ID id, Event event) {
         if (event.isLeaf()) {
-            GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
-            er.setC(er.getC() + event.maxDepth() + 1);
-            return er;
+            return growLeafEvent(id, event);
         }
-        if (id.getLeft() != null && id.getLeft().equals(IDs.zero())) {
-            GrowResult er = grow(id.getRight(), event.getRight());
-            Event e = Events.with(event.getValue(), event.getLeft(), er.getEvent());
-            return new GrowResult(e, er.getC() + 1);
+        else if (id.getLeft().isZero()) {
+            return growOnRight(id, event);
         }
-        if (id.getRight() != null && id.getRight().equals(IDs.zero())) {
-            GrowResult er = grow(id.getLeft(), event.getLeft());
-            Event e = Events.with(event.getValue(), er.getEvent(), event.getRight());
-            return new GrowResult(e, er.getC() + 1);
+        else if (id.getRight().isZero()) {
+            return growOnLeft(id, event);
         }
-        GrowResult left = grow(id.getLeft(), event.getLeft());
-        GrowResult right = grow(id.getRight(), event.getRight());
-        if (left.getC() < right.getC()) {
-            Event e = Events.with(event.getValue(), left.getEvent(), event.getRight());
-            return new GrowResult(e, left.getC() + 1);
-        } else {
-            Event e = Events.with(event.getValue(), event.getLeft(), right.getEvent());
-            return new GrowResult(e, right.getC() + 1);
+        else {
+            return growOnBothSides(id, event);
+        }
+    }
+
+    private static GrowResult growLeafEvent(ID id, Event event) {
+        GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
+        er.setCost(er.getCost() + event.maxDepth() + 1);
+        return er;
+    }
+
+    private static GrowResult growOnRight(ID id, Event event) {
+        GrowResult rightGrowth = growRight(id, event);
+        return rightGrowth(event, rightGrowth);
+    }
+
+    private static GrowResult growRight(ID id, Event event) {
+        return grow(id.getRight(), event.getRight());
+    }
+
+    private static GrowResult rightGrowth(Event event, GrowResult growth) {
+        Event result = Events.with(event.getValue(),
+                event.getLeft(), growth.getEvent());
+        return new GrowResult(result, growth.getCost() + 1);
+    }
+
+    private static GrowResult growOnLeft(ID id, Event event) {
+        GrowResult leftGrowth = growLeft(id, event);
+        return leftGrowth(event, leftGrowth);
+    }
+
+    private static GrowResult growLeft(ID id, Event event) {
+        return grow(id.getLeft(), event.getLeft());
+    }
+
+    private static GrowResult leftGrowth(Event event, GrowResult growth) {
+        Event result = Events.with(event.getValue(),
+                growth.getEvent(), event.getRight());
+        return new GrowResult(result, growth.getCost() + 1);
+    }
+
+    private static GrowResult growOnBothSides(ID id, Event event) {
+        GrowResult leftGrowth = growLeft(id, event);
+        GrowResult rightGrowth = growRight(id, event);
+        if (leftGrowth.getCost() < rightGrowth.getCost()) {
+            return leftGrowth(event, leftGrowth);
+        }
+        else {
+            return rightGrowth(event, rightGrowth);
         }
     }
 

--- a/src/main/java/itc4j/Grower.java
+++ b/src/main/java/itc4j/Grower.java
@@ -9,8 +9,12 @@ package itc4j;
  * @version 29/mai/2015
  */
 final class Grower {
+    
+    static Event grow(ID id, Event event) {
+        return innerGrow(id, event).getEvent();
+    }
 
-    static GrowResult grow(ID id, Event event) {
+    private static GrowResult innerGrow(ID id, Event event) {
         if (id.isLeaf()) {
             return growLeafID(id, event);
         }
@@ -44,7 +48,7 @@ final class Grower {
     }
 
     private static GrowResult growLeafEvent(ID id, Event event) {
-        GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
+        GrowResult er = innerGrow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
         er.setCost(er.getCost() + event.maxDepth() + 1);
         return er;
     }
@@ -55,7 +59,7 @@ final class Grower {
     }
 
     private static GrowResult growRight(ID id, Event event) {
-        return grow(id.getRight(), event.getRight());
+        return innerGrow(id.getRight(), event.getRight());
     }
 
     private static GrowResult rightGrowth(Event event, GrowResult growth) {
@@ -70,7 +74,7 @@ final class Grower {
     }
 
     private static GrowResult growLeft(ID id, Event event) {
-        return grow(id.getLeft(), event.getLeft());
+        return innerGrow(id.getLeft(), event.getLeft());
     }
 
     private static GrowResult leftGrowth(Event event, GrowResult growth) {

--- a/src/main/java/itc4j/Grower.java
+++ b/src/main/java/itc4j/Grower.java
@@ -1,0 +1,43 @@
+
+package itc4j;
+
+/**
+ * Grower
+ *
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
+ * @version 29/mai/2015
+ */
+final class Grower {
+
+    static GrowResult grow(ID id, Event event) {
+        if (id.equals(IDs.one()) && event.isLeaf())
+            return new GrowResult(Events.with(event.getValue() + 1), 0);
+        if (event.isLeaf()) {
+            GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
+            er.setC(er.getC() + event.maxDepth() + 1);
+            return er;
+        }
+        if (id.getLeft() != null && id.getLeft().equals(IDs.zero())) {
+            GrowResult er = grow(id.getRight(), event.getRight());
+            Event e = Events.with(event.getValue(), event.getLeft(), er.getEvent());
+            return new GrowResult(e, er.getC() + 1);
+        }
+        if (id.getRight() != null && id.getRight().equals(IDs.zero())) {
+            GrowResult er = grow(id.getLeft(), event.getLeft());
+            Event e = Events.with(event.getValue(), er.getEvent(), event.getRight());
+            return new GrowResult(e, er.getC() + 1);
+        }
+        GrowResult left = grow(id.getLeft(), event.getLeft());
+        GrowResult right = grow(id.getRight(), event.getRight());
+        if (left.getC() < right.getC()) {
+            Event e = Events.with(event.getValue(), left.getEvent(), event.getRight());
+            return new GrowResult(e, left.getC() + 1);
+        } else {
+            Event e = Events.with(event.getValue(), event.getLeft(), right.getEvent());
+            return new GrowResult(e, right.getC() + 1);
+        }
+    }
+
+    private Grower() { }
+    
+}

--- a/src/main/java/itc4j/Grower.java
+++ b/src/main/java/itc4j/Grower.java
@@ -4,6 +4,7 @@ package itc4j;
 /**
  * Grower
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */

--- a/src/main/java/itc4j/ID.java
+++ b/src/main/java/itc4j/ID.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 /**
  * @author Sina Bagherzadeh
  */
-public abstract class ID implements Cloneable {
+abstract class ID implements Cloneable {
     
     abstract ID getLeft();
     

--- a/src/main/java/itc4j/ID.java
+++ b/src/main/java/itc4j/ID.java
@@ -1,12 +1,9 @@
 package itc4j;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 /**
  * @author Sina Bagherzadeh
  */
-abstract class ID implements Cloneable {
+abstract class ID {
     
     abstract ID getLeft();
     
@@ -23,16 +20,5 @@ abstract class ID implements Cloneable {
     abstract ID[] split();
 
     abstract ID sum(ID other);
-
-    @Override
-    protected ID clone() {
-        try {
-            return (ID)super.clone();
-        }
-        catch(CloneNotSupportedException ex) {
-            Logger.getLogger(ID.class.getName()).log(Level.SEVERE, null, ex);
-            return null;
-        }
-    }
     
 }

--- a/src/main/java/itc4j/IDs.java
+++ b/src/main/java/itc4j/IDs.java
@@ -9,15 +9,15 @@ package itc4j;
  */
 final class IDs {
     
-    public static ID zero() {
+    static ID zero() {
         return new LeafID(0);
     }
     
-    public static ID one() {
+    static ID one() {
         return new LeafID(1);
     }
     
-    public static ID with(ID id1, ID id2) {
+    static ID with(ID id1, ID id2) {
         return new NonLeafID(id1, id2);
     }
 

--- a/src/main/java/itc4j/LeafEvent.java
+++ b/src/main/java/itc4j/LeafEvent.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 /**
  * LeafEvent
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */
@@ -68,7 +69,7 @@ final class LeafEvent extends Event implements Serializable, Cloneable {
     }
 
     @Override
-    public Event normalize() {
+    Event normalize() {
         return this;
     }
 
@@ -111,7 +112,7 @@ final class LeafEvent extends Event implements Serializable, Cloneable {
     }
 
     @Override
-    public Event clone() {
+    protected Event clone() {
         return super.clone();
     }
     

--- a/src/main/java/itc4j/LeafEvent.java
+++ b/src/main/java/itc4j/LeafEvent.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */
-final class LeafEvent extends Event implements Serializable, Cloneable {
+final class LeafEvent extends Event implements Serializable {
 
     private static final long serialVersionUID = -7441138365249091187L;
     
@@ -109,11 +109,6 @@ final class LeafEvent extends Event implements Serializable, Cloneable {
     @Override
     public String toString() {
         return String.valueOf(value);
-    }
-
-    @Override
-    protected Event clone() {
-        return super.clone();
     }
     
 }

--- a/src/main/java/itc4j/LeafID.java
+++ b/src/main/java/itc4j/LeafID.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 /**
  * LeafID
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 28/mai/2015
  */

--- a/src/main/java/itc4j/LeafID.java
+++ b/src/main/java/itc4j/LeafID.java
@@ -98,10 +98,5 @@ final class LeafID extends ID implements Serializable {
     public String toString() {
         return String.valueOf(value);
     }
-
-    @Override
-    protected ID clone() {
-        return super.clone();
-    }
     
 }

--- a/src/main/java/itc4j/NonLeafEvent.java
+++ b/src/main/java/itc4j/NonLeafEvent.java
@@ -1,5 +1,6 @@
 package itc4j;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -9,11 +10,13 @@ import java.util.Objects;
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */
-final class NonLeafEvent extends Event {
+final class NonLeafEvent extends Event implements Serializable {
+
+    private static final long serialVersionUID = 4390279981057181340L;
     
     private final int value;
-    private Event left;
-    private Event right;
+    private final Event left;
+    private final Event right;
 
     NonLeafEvent(int value, Event left, Event right) {
         this.value = value;
@@ -164,14 +167,6 @@ final class NonLeafEvent extends Event {
     @Override
     public String toString() {
         return "(" + value + ", " + left + ", " + right + ")";
-    }
-
-    @Override
-    protected Event clone() {
-        NonLeafEvent clone = (NonLeafEvent)super.clone();
-        clone.right = right.clone();
-        clone.left = left.clone();
-        return clone;
     }
 
 }

--- a/src/main/java/itc4j/NonLeafEvent.java
+++ b/src/main/java/itc4j/NonLeafEvent.java
@@ -1,4 +1,3 @@
-
 package itc4j;
 
 import java.util.Objects;
@@ -6,6 +5,7 @@ import java.util.Objects;
 /**
  * NonLeafEvent
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 29/mai/2015
  */
@@ -69,7 +69,7 @@ final class NonLeafEvent extends Event {
     }
 
     @Override
-    public Event normalize() {
+    Event normalize() {
         if (left.isLeaf() && right.isLeaf() && left.getValue() == right.getValue()) {
             return Events.with(value + left.getValue());
         }
@@ -167,7 +167,7 @@ final class NonLeafEvent extends Event {
     }
 
     @Override
-    public Event clone() {
+    protected Event clone() {
         NonLeafEvent clone = (NonLeafEvent)super.clone();
         clone.right = right.clone();
         clone.left = left.clone();

--- a/src/main/java/itc4j/NonLeafID.java
+++ b/src/main/java/itc4j/NonLeafID.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 /**
  * NonLeafID
  *
+ * @author Sina Bagherzadeh
  * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  * @version 28/mai/2015
  */
@@ -21,11 +22,11 @@ final class NonLeafID extends ID implements Serializable {
         this.right = right;
     }
 
-    public ID getLeft() {
+    ID getLeft() {
         return left;
     }
 
-    public ID getRight() {
+    ID getRight() {
         return right;
     }
 
@@ -44,14 +45,6 @@ final class NonLeafID extends ID implements Serializable {
         return false;
     }
 
-    protected boolean hasRight() {
-        return right != null;
-    }
-
-    protected boolean hasLeft() {
-        return left != null;
-    }
-
     @Override
     ID normalize() {
         normalizeChildren();
@@ -67,12 +60,8 @@ final class NonLeafID extends ID implements Serializable {
     }
 
     private void normalizeChildren() {
-        if (hasRight()) {
-            normalizeRight();
-        }
-        if (hasLeft()) {
-            normalizeLeft();
-        }
+        normalizeRight();
+        normalizeLeft();
     }
 
     private void normalizeRight() {
@@ -85,10 +74,10 @@ final class NonLeafID extends ID implements Serializable {
 
     @Override
     ID[] split() {
-        if (hasLeft() && left.isZero()) {
+        if (left.isZero()) {
             return splitWithLeftZero();
         }
-        else if (hasRight() && getRight().isZero()) {
+        else if (right.isZero()) {
             return splitWithRightZero();
         }
         else {
@@ -121,7 +110,7 @@ final class NonLeafID extends ID implements Serializable {
         if (other.isZero()) {
             return this;
         }
-        else if (other instanceof NonLeafID) {
+        else if (!other.isLeaf()) {
             return sumNonLeaf((NonLeafID)other);
         }
         else {
@@ -129,7 +118,7 @@ final class NonLeafID extends ID implements Serializable {
         }
     }
 
-    private ID sumNonLeaf(NonLeafID other) {
+    private ID sumNonLeaf(ID other) {
         ID leftSum = left.sum(other.getLeft());
         ID rightSum = right.sum(other.getRight());
         ID sum = IDs.with(leftSum, rightSum);
@@ -138,12 +127,13 @@ final class NonLeafID extends ID implements Serializable {
 
     @Override
     public boolean equals(Object object) {
-        if(!(object instanceof NonLeafID)) {
+        if (!(object instanceof NonLeafID)) {
             return false;
         }
         else {
             NonLeafID other = (NonLeafID)object;
-            return left.equals(other.getLeft()) && right.equals(other.getRight());
+            return left.equals(other.getLeft()) &&
+                   right.equals(other.getRight());
         }
     }
 
@@ -158,14 +148,10 @@ final class NonLeafID extends ID implements Serializable {
     }
 
     @Override
-    public ID clone() {
+    protected ID clone() {
         NonLeafID clone = (NonLeafID)super.clone();
-        if (hasLeft()) {
-            clone.left = left.clone();
-        }
-        if (hasRight()) {
-            clone.right = right.clone();
-        }
+        clone.left = left.clone();
+        clone.right = right.clone();
         return clone;
     }
     

--- a/src/main/java/itc4j/NonLeafID.java
+++ b/src/main/java/itc4j/NonLeafID.java
@@ -14,8 +14,8 @@ final class NonLeafID extends ID implements Serializable {
 
     private static final long serialVersionUID = -5030081211956985797L;
 
-    private ID left;
-    private ID right;
+    private final ID left;
+    private final ID right;
 
     NonLeafID(ID left, ID right) {
         this.left = left;
@@ -47,7 +47,10 @@ final class NonLeafID extends ID implements Serializable {
 
     @Override
     ID normalize() {
-        normalizeChildren();
+        return normalize(left.normalize(), right.normalize());
+    }
+
+    private static ID normalize(ID left, ID right) {
         if (left.isZero() && right.isZero()) {
             return IDs.zero();
         }
@@ -55,21 +58,8 @@ final class NonLeafID extends ID implements Serializable {
             return IDs.one();
         }
         else {
-            return this;
+            return IDs.with(left, right);
         }
-    }
-
-    private void normalizeChildren() {
-        normalizeRight();
-        normalizeLeft();
-    }
-
-    private void normalizeRight() {
-        right = right.normalize();
-    }
-
-    private void normalizeLeft() {
-        left = left.normalize();
     }
 
     @Override
@@ -82,8 +72,8 @@ final class NonLeafID extends ID implements Serializable {
         }
         else {
             return new ID[] {
-                IDs.with(left.clone(), IDs.zero()),
-                IDs.with(IDs.zero(), right.clone())
+                IDs.with(left, IDs.zero()),
+                IDs.with(IDs.zero(), right)
             };
         }
     }
@@ -145,14 +135,6 @@ final class NonLeafID extends ID implements Serializable {
     @Override
     public String toString() {
         return "(" + left + ", " + right + ")";
-    }
-
-    @Override
-    protected ID clone() {
-        NonLeafID clone = (NonLeafID)super.clone();
-        clone.left = left.clone();
-        clone.right = right.clone();
-        return clone;
     }
     
 }

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -5,9 +5,12 @@ import java.io.Serializable;
 /**
  * @author Sina Bagherzadeh
  */
-public final class Stamp implements Serializable {
-    private ID id;
-    private Event event;
+public final class Stamp implements Cloneable, Serializable {
+
+    private static final long serialVersionUID = 1750149585711104601L;
+    
+    private final ID id;
+    private final Event event;
 
     public Stamp() {
         id = IDs.one();
@@ -19,86 +22,52 @@ public final class Stamp implements Serializable {
         this.event = event;
     }
 
-    static Stamp[] fork(Stamp s) {
-        Stamp[] result = new Stamp[2];
-        ID[] ids = s.id.split();
-        result[0] = new Stamp(ids[0], s.event);
-        result[1] = new Stamp(ids[1], s.event);
-        return result;
+    ID getId() {
+        return id;
     }
 
-    static Stamp[] peek(Stamp s) {
-        return new Stamp[]{new Stamp(s.id, s.event), new Stamp(IDs.zero(), s.event)};
+    Event getEvent() {
+        return event;
     }
 
-    static Stamp join(Stamp s1, Stamp s2) {
-        return new Stamp(s1.id.sum(s2.id), s1.event.join(s2.event));
+    Stamp[] fork() {
+        ID[] ids = id.split();
+        return new Stamp[] {
+            new Stamp(ids[0], event),
+            new Stamp(ids[1], event)
+        };
     }
 
-    private static Event fill(ID id, Event event) {
-        if (id.equals(IDs.zero()))
-            return event;
-        if (id.equals(IDs.one()))
-            return Events.with(event.max());
-        if (event.isLeaf())
-            return Events.with(event.getValue());
-        if (id.getLeft() != null && id.getLeft().equals(IDs.one())) {
-            Event er = fill(id.getRight(), event.getRight());
-            int max = Math.max(event.getLeft().max(), er.min());
-            return Events.with(event.getValue(), Events.with(max), er).normalize();
-        }
-        if (id.getRight() != null && id.getRight().equals(IDs.one())) {
-            Event el = fill(id.getLeft(), event.getLeft());
-            int max = Math.max(event.getRight().max(), el.min());
-            return Events.with(event.getValue(), el, Events.with(max)).normalize();
-        }
-        return Events.with(event.getValue(), fill(id.getLeft(), event.getLeft()),
-                fill(id.getRight(), event.getRight())).normalize();
+    Stamp[] peek() {
+        return new Stamp[] {
+            new Stamp(id, event),
+            new Stamp(IDs.zero(), event)
+        };
     }
 
-    private static GrowResult grow(ID id, Event event) {
-        if (id.equals(IDs.one()) && event.isLeaf())
-            return new GrowResult(Events.with(event.getValue() + 1), 0);
-        if (event.isLeaf()) {
-            GrowResult er = grow(id, Events.with(event.getValue(), Events.zero(), Events.zero()));
-            er.setC(er.getC() + event.maxDepth() + 1);
-            return er;
-        }
-        if (id.getLeft() != null && id.getLeft().equals(IDs.zero())) {
-            GrowResult er = grow(id.getRight(), event.getRight());
-            Event e = Events.with(event.getValue(), event.getLeft(), er.getEvent());
-            return new GrowResult(e, er.getC() + 1);
-        }
-        if (id.getRight() != null && id.getRight().equals(IDs.zero())) {
-            GrowResult er = grow(id.getLeft(), event.getLeft());
-            Event e = Events.with(event.getValue(), er.getEvent(), event.getRight());
-            return new GrowResult(e, er.getC() + 1);
-        }
-        GrowResult left = grow(id.getLeft(), event.getLeft());
-        GrowResult right = grow(id.getRight(), event.getRight());
-        if (left.getC() < right.getC()) {
-            Event e = Events.with(event.getValue(), left.getEvent(), event.getRight());
-            return new GrowResult(e, left.getC() + 1);
-        } else {
-            Event e = Events.with(event.getValue(), event.getLeft(), right.getEvent());
-            return new GrowResult(e, right.getC() + 1);
-        }
+    Stamp join(Stamp other) {
+        ID idSum = id.sum(other.id);
+        Event eventJoin = event.join(other.event);
+        return new Stamp(idSum, eventJoin);
     }
 
-    static Stamp event(Stamp s) {
-        Event e = fill(s.id, s.event);
-        if (!s.event.equals(e))
-            return new Stamp(s.id, e);
+    Stamp event() {
+        Event filled = Filler.fill(id, event);
+        if (!filled.equals(event)) {
+            return new Stamp(id, filled);
+        }
         else {
-            GrowResult gr = grow(s.id, s.event);
-            return new Stamp(s.id, gr.getEvent());
+            GrowResult growth = Grower.grow(id, event);
+            return new Stamp(id, growth.getEvent());
         }
     }
 
+    @Override
     public String toString() {
         return "(" + id + ", " + event + ")";
     }
 
+    @Override
     public Stamp clone() {
         return new Stamp(id.clone(), event.clone());
     }
@@ -121,20 +90,22 @@ public final class Stamp implements Serializable {
 
     //----------------------------------------- API methods --------------------------------------
 
-    public Stamp[] send(Stamp s) {
-        return peek(event(s.clone()));
+    public static Stamp[] send(Stamp stamp) {
+        return stamp.event().peek();
     }
 
-    public Stamp receive(Stamp s1, Stamp s2) {
-        return event(join(s1.clone(), s2.clone()));
+    public static Stamp receive(Stamp stamp1, Stamp stamp2) {
+        Stamp join = stamp1.join(stamp2);
+        return join.event();
     }
 
-    public Stamp[] sync(Stamp s1, Stamp s2) {
-        return fork(join(s1.clone(), s2.clone()));
+    public static Stamp[] sync(Stamp stamp1, Stamp stamp2) {
+        Stamp join = stamp1.join(stamp2);
+        return join.fork();
     }
 
-    public static boolean leq(Stamp s1, Stamp s2) {
-        return s1.event.leq(s2.event);
+    public static boolean leq(Stamp stamp1, Stamp stamp2) {
+        return stamp1.event.leq(stamp2.event);
     }
 
 }

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -57,8 +57,7 @@ public final class Stamp implements Cloneable, Serializable {
             return new Stamp(id, filled);
         }
         else {
-            GrowResult growth = Grower.grow(id, event);
-            return new Stamp(id, growth.getEvent());
+            return new Stamp(id, Grower.grow(id, event));
         }
     }
 

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 /**
  * @author Sina Bagherzadeh
  */
-public final class Stamp implements Cloneable, Serializable {
+public final class Stamp implements Serializable {
 
     private static final long serialVersionUID = 1750149585711104601L;
     
@@ -67,11 +67,6 @@ public final class Stamp implements Cloneable, Serializable {
     }
 
     @Override
-    public Stamp clone() {
-        return new Stamp(id.clone(), event.clone());
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (!(o instanceof Stamp)) {
             return false;
@@ -91,22 +86,20 @@ public final class Stamp implements Cloneable, Serializable {
 
     //----------------------------------------- API methods --------------------------------------
 
-    public static Stamp[] send(Stamp stamp) {
-        return stamp.event().peek();
+    public Stamp[] send() {
+        return event().peek();
     }
 
-    public static Stamp receive(Stamp stamp1, Stamp stamp2) {
-        Stamp join = stamp1.join(stamp2);
-        return join.event();
+    public Stamp receive(Stamp other) {
+        return join(other).event();
     }
 
-    public static Stamp[] sync(Stamp stamp1, Stamp stamp2) {
-        Stamp join = stamp1.join(stamp2);
-        return join.fork();
+    public Stamp[] sync(Stamp other) {
+        return join(other).fork();
     }
 
-    public static boolean leq(Stamp stamp1, Stamp stamp2) {
-        return stamp1.event.leq(stamp2.event);
+    public boolean leq(Stamp other) {
+        return event.leq(other.event);
     }
 
 }

--- a/src/main/java/itc4j/Stamp.java
+++ b/src/main/java/itc4j/Stamp.java
@@ -30,7 +30,7 @@ public final class Stamp implements Cloneable, Serializable {
         return event;
     }
 
-    Stamp[] fork() {
+    public Stamp[] fork() {
         ID[] ids = id.split();
         return new Stamp[] {
             new Stamp(ids[0], event),
@@ -38,20 +38,20 @@ public final class Stamp implements Cloneable, Serializable {
         };
     }
 
-    Stamp[] peek() {
+    public Stamp[] peek() {
         return new Stamp[] {
             new Stamp(id, event),
             new Stamp(IDs.zero(), event)
         };
     }
 
-    Stamp join(Stamp other) {
+    public Stamp join(Stamp other) {
         ID idSum = id.sum(other.id);
         Event eventJoin = event.join(other.event);
         return new Stamp(idSum, eventJoin);
     }
 
-    Stamp event() {
+    public Stamp event() {
         Event filled = Filler.fill(id, event);
         if (!filled.equals(event)) {
             return new Stamp(id, filled);
@@ -74,17 +74,19 @@ public final class Stamp implements Cloneable, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Stamp stamp = (Stamp) o;
-        return !(event != null ? !event.equals(stamp.event) : stamp.event != null) &&
-                !(id != null ? !id.equals(stamp.id) : stamp.id != null);
+        if (!(o instanceof Stamp)) {
+            return false;
+        }
+        else {
+            Stamp other = (Stamp) o;
+            return id.equals(other.getId()) && event.equals(other.getEvent());
+        }
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (event != null ? event.hashCode() : 0);
+        int result = id.hashCode();
+        result = 31 * result + event.hashCode();
         return result;
     }
 

--- a/src/test/java/itc4j/EventTest.java
+++ b/src/test/java/itc4j/EventTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sina Bagherzadeh
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class EventTest {
     

--- a/src/test/java/itc4j/IDTest.java
+++ b/src/test/java/itc4j/IDTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.*;
 
 /**
  * @author Sina Bagherzadeh
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class IDTest {
     

--- a/src/test/java/itc4j/StampTest.java
+++ b/src/test/java/itc4j/StampTest.java
@@ -6,7 +6,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static itc4j.Stamp.leq;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -118,8 +117,8 @@ public class StampTest {
     public void testLeq() {
         Stamp s1 = new Stamp();
         Stamp s2 = new Stamp();
-        Assert.assertTrue(leq(s1, s2.event()));
-        Assert.assertFalse(leq(s2.event(), s1));
+        Assert.assertTrue(s1.leq(s2.event()));
+        Assert.assertFalse(s2.event().leq(s1));
     }
     
     private static void assertIntEquals(int expected, int actual) {

--- a/src/test/java/itc4j/StampTest.java
+++ b/src/test/java/itc4j/StampTest.java
@@ -1,47 +1,133 @@
 package itc4j;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
-import static itc4j.Stamp.*;
+import static itc4j.Stamp.leq;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sina Bagherzadeh
  */
 public class StampTest {
+    
+    private Stamp seedStamp;
+    private Stamp forkedStamp1;
+    private Stamp forkedStamp2;
+    private Stamp joinedStamp;
+    private List<Stamp> stamps;
+    
+    @Before
+    public void setup() {
+        seedStamp = new Stamp();
+        Stamp[] fork = seedStamp.event().fork();
+        forkedStamp1 = fork[0];
+        forkedStamp2 = fork[1].event();
+        joinedStamp = forkedStamp1.join(forkedStamp2);
+        stamps = Arrays.asList(seedStamp, forkedStamp1, forkedStamp2, joinedStamp);
+    }
+    
+    @Test
+    public void testSeedStampIsOneZero() {
+        assertTrue(seedStamp.getId().isOne());
+        assertTrue(seedStamp.getEvent().isLeaf());
+        assertIntEquals(0, seedStamp.getEvent().getValue());
+    }
+    
+    @Test
+    public void testEquals() {
+        assertTrue(seedStamp.equals(new Stamp()));
+        assertFalse(seedStamp.equals(forkedStamp1));
+        assertTrue(forkedStamp1.equals(forkedStamp1));
+        assertFalse(forkedStamp1.equals(forkedStamp2));
+    }
+    
+    @Test
+    public void testPeek() {
+        for (Stamp stamp : stamps) {
+            Stamp[] peek = stamp.peek();
+            
+            assertIntEquals(2, peek.length);
+            assertTrue(peek[0].equals(stamp));
+            assertTrue(peek[1].getId().isZero());
+            assertTrue(peek[1].getEvent().equals(stamp.getEvent()));
+            assertNormalizedStamp(peek[0]);
+            assertNormalizedStamp(peek[1]);
+        }
+    }
+    
+    @Test
+    public void testFork() {
+        for (Stamp stamp : stamps) {
+            Stamp[] fork = stamp.fork();
+            ID[] splitIDs = stamp.getId().split();
+            
+            assertIntEquals(2, fork.length);
+            assertEquals(stamp.getEvent(), fork[0].getEvent());
+            assertEquals(stamp.getEvent(), fork[1].getEvent());
+            assertEquals(splitIDs[0], fork[0].getId());
+            assertEquals(splitIDs[1], fork[1].getId());
+            assertNormalizedStamp(fork[0]);
+            assertNormalizedStamp(fork[1]);
+        }
+    }
+    
+    @Test
+    public void testJoin() {
+        Stamp expected = new Stamp(IDs.one(),
+                Events.with(1, Events.zero(), Events.with(1)));
+        
+        assertEquals(expected, forkedStamp1.join(forkedStamp2));
+        assertEquals(expected, forkedStamp2.join(forkedStamp1));
+        assertNormalizedStamp(forkedStamp1.join(forkedStamp2));
+    }
+    
+    @Test
+    public void testEvent() {
+        for (Stamp stamp : stamps) {
+            Stamp evented = stamp.event();
+            
+            assertTrue(stamp.getEvent().leq(evented.getEvent()));
+            assertNormalizedStamp(evented);
+        }
+    }
 
     @Test
-    public void testAll() {
-        Stamp stamp = new Stamp();
-        Stamp[] fork1 = fork(stamp);
-        System.out.println("fork1[0] = " + fork1[0]);
-        System.out.println("fork1[1] = " + fork1[1]);
-        Stamp event1 = event(fork1[0]);
-        System.out.println("event1 = " + event1);
-        Stamp event2 = event(event(fork1[1]));
-        System.out.println("event2 = " + event2);
-        Stamp[] fork2 = fork(event1);
-        System.out.println("fork2[0] = " + fork2[0]);
-        System.out.println("fork2[1] = " + fork2[1]);
-        Stamp event11 = event(fork2[0]);
-        System.out.println("event11 = " + event11);
-        Stamp join1 = join(fork2[1], event2);
-        System.out.println("join1 = " + join1);
-        Stamp[] fork22 = fork(join1);
-        System.out.println("fork22[0] = " + fork22[0]);
-        System.out.println("fork22[1] = " + fork22[1]);
-        Stamp join2 = join(fork22[0], event11);
-        System.out.println("join2 = " + join2);
-        Stamp event3 = event(join2);
-        System.out.println("event3 = " + event3);
-        Assert.assertEquals(new Stamp(IDs.with(IDs.one(), IDs.zero()), Events.with(2)), event3);
+    public void testForkEventJoin() {
+        Stamp[] fork1 = seedStamp.fork();
+        Stamp event1 = fork1[0].event();
+        Stamp event2 = fork1[1].event().event();
+        Stamp[] fork2 = event1.fork();
+        Stamp event11 = fork2[0].event();
+        Stamp join1 = fork2[1].join(event2);
+        Stamp[] fork22 = join1.fork();
+        Stamp join2 = fork22[0].join(event11);
+        Stamp event3 = join2.event();
+        
+        Stamp expected = new Stamp(IDs.with(IDs.one(), IDs.zero()), Events.with(2));
+        assertEquals(expected, event3);
     }
 
     @Test
     public void testLeq() {
         Stamp s1 = new Stamp();
         Stamp s2 = new Stamp();
-        Assert.assertTrue(leq(s1, event(s2)));
-        Assert.assertFalse(leq(event(s2), s1));
+        Assert.assertTrue(leq(s1, s2.event()));
+        Assert.assertFalse(leq(s2.event(), s1));
     }
+    
+    private static void assertIntEquals(int expected, int actual) {
+        assertEquals((long)expected, (long)actual);
+    }
+    
+    private static void assertNormalizedStamp(Stamp stamp) {
+        assertEquals(stamp.getId(), stamp.getId().normalize());
+        assertEquals(stamp.getEvent(), stamp.getEvent().normalize());
+    }
+    
 }

--- a/src/test/java/itc4j/StampTest.java
+++ b/src/test/java/itc4j/StampTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Sina Bagherzadeh
+ * @author Benjamim Sonntag <benjamimsonntag@gmail.com>
  */
 public class StampTest {
     


### PR DESCRIPTION
`fill()` and `grow()` methods didn't really belong in `Stamp` class (because they didn't work with Stamps), so I moved them to separate helper classes: `Filler` and `Grower`.
Also, while doing this, I changed the return type of `grow()` to `Event` because `Stamp` doesn't need to know about `GrowResult`.

I also turned `Stamp` class methods into instance methods for ease of use and added more tests for Stamps.

Beside these changes I:
- Made all classes package private except `Stamp`;
- Made all classes immutable (some already were), and removed `clone()` methods (immutable classes don't really need `clone()`);
- Gave credit to you in most new classes since the code is actually yours (I just refactored and moved it around).
