### PR TITLE
Fix an issue with deserializing a `Stamp` in a structure.

### DIFF
--- a/itc4j-jackson/src/main/java/itc4j/StampDeserializer.java
+++ b/itc4j-jackson/src/main/java/itc4j/StampDeserializer.java
@@ -24,7 +24,13 @@ public class StampDeserializer extends StdDeserializer<Stamp>
     JsonToken t = jp.getCurrentToken();
     assert t == JsonToken.START_ARRAY;
 
-    return new Stamp(handleID(jp, ctxt), handleEvent(jp, ctxt));
+    final Stamp s = new Stamp(handleID(jp, ctxt), handleEvent(jp, ctxt));
+
+    // Discard the END_ARRAY token
+    t = jp.nextToken();
+    assert t == JsonToken.END_ARRAY;
+
+    return s;
   }
 
   /**

--- a/itc4j-jackson/src/test/java/itc4j/ContainsStamp.java
+++ b/itc4j-jackson/src/test/java/itc4j/ContainsStamp.java
@@ -1,0 +1,50 @@
+package itc4j;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Test class containing a Stamp, to ensure that they're correctly deserialized.
+ *
+ * @author Ian Eure <ian.eure@gmail.com>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"clock", "foo"})
+public class ContainsStamp {
+
+  @JsonProperty("foo")
+  private String foo;
+
+  @JsonProperty("clock")
+  private Stamp clock;
+
+  public ContainsStamp(Stamp clock,
+                       String foo) {
+    this.clock = clock;
+    this.foo = foo;
+  }
+
+
+  public ContainsStamp() {}
+
+  @JsonProperty("foo")
+  public String getFoo() {
+    return foo;
+  }
+
+  @JsonProperty("foo")
+  public void setFoo(String foo) {
+    this.foo = foo;
+  }
+
+  @JsonProperty("clock")
+  public Stamp getClock() {
+    return clock;
+  }
+
+  @JsonProperty("clock")
+  public void setClock(Stamp clock) {
+    this.clock = clock;
+  }
+}

--- a/itc4j-jackson/src/test/java/itc4j/SerializationTest.java
+++ b/itc4j-jackson/src/test/java/itc4j/SerializationTest.java
@@ -34,4 +34,14 @@ public class SerializationTest {
     final Stamp ns = json.readValue(js, Stamp.class);
     assertEquals(s, ns);
   }
+
+  @Test
+  public void testMemberSerialization() throws Exception {
+    final ContainsStamp inp = new ContainsStamp(new Stamp(), "test");
+    final String ser = json.writeValueAsString(inp);
+
+    final ContainsStamp out = json.readValue(ser, ContainsStamp.class);
+    assertEquals(inp.getClock(), out.getClock());
+    assertEquals(inp.getFoo(), out.getFoo());
+  }
 }


### PR DESCRIPTION
The final `END_ARRAY` token wasn’t discarded after deserializing `Stamp`, which caused all fields in the payload after the `Stamp` to be skipped and turned into `null`.

re #4, #5
